### PR TITLE
feat(TextBox): enhanced selection behavior

### DIFF
--- a/demos/base.lua
+++ b/demos/base.lua
@@ -66,7 +66,6 @@ function begin_frame()
     local mouse_x = mup_input.xmouse
     local mouse_y = mup_input.ymouse
     local lmb_down = mup_input.leftclick
-
     ugui.begin_frame({
         mouse_position = {
             x = mouse_x,
@@ -79,6 +78,7 @@ function begin_frame()
             x = window_size.width,
             y = window_size.height - 23,
         },
+        shift = mup_input.shift,
     })
     mouse_wheel = 0
 end

--- a/src/ugui/controls/textbox.lua
+++ b/src/ugui/controls/textbox.lua
@@ -118,10 +118,16 @@ ugui.registry.textbox = {
                         end
                     elseif e.keycode == ugui.keycodes.VK_LEFT then
                         if e.ctrl then
-                            local prev_word, _ = surrounding_word_index(data.text, data.caret_index)
-                            data.selection_start = prev_word
-                            data.selection_end = prev_word
-                            data.caret_index = prev_word
+                            local prev_word, _ = surrounding_word_index(data.text, lower_selection)
+
+                            if e.shift then
+                                data.selection_start = prev_word
+                                data.caret_index = prev_word
+                            else
+                                data.selection_start = prev_word
+                                data.selection_end = prev_word
+                                data.caret_index = prev_word
+                            end
                         else
                             if has_selection then
                                 data.selection_start = lower_selection
@@ -135,10 +141,15 @@ ugui.registry.textbox = {
                         end
                     elseif e.keycode == ugui.keycodes.VK_RIGHT then
                         if e.ctrl then
-                            local _, next_word = surrounding_word_index(data.text, data.caret_index)
-                            data.selection_start = next_word
-                            data.selection_end = next_word
-                            data.caret_index = next_word
+                            local _, next_word = surrounding_word_index(data.text, higher_selection)
+                            if e.shift then
+                                data.selection_end = next_word
+                                data.caret_index = next_word
+                            else
+                                data.selection_start = next_word
+                                data.selection_end = next_word
+                                data.caret_index = next_word
+                            end
                         else
                             if has_selection then
                                 data.selection_start = higher_selection

--- a/src/ugui/controls/textbox.lua
+++ b/src/ugui/controls/textbox.lua
@@ -80,12 +80,20 @@ ugui.registry.textbox = {
 
         local index_at_mouse = ugui.internal.get_caret_index(data.text, data.scroll_offset, ugui.internal.environment.mouse_position.x - control.rectangle.x)
 
-        -- If the control was just clicked, start a new selection.
+        -- If the control was just clicked, start a new selection or create/extend one with shift held.
         if ugui.internal.clicked_control == control.uid then
-            data.caret_index = index_at_mouse
-            data.selection_start = index_at_mouse
-            data.selection_end = index_at_mouse
-            data.last_changed_anchor = 'caret'
+            if ugui.internal.environment.shift then
+                local anchor = (data.caret_index == data.selection_end) and data.selection_start or data.selection_end
+                data.selection_start = anchor
+                data.selection_end = index_at_mouse
+                data.caret_index = index_at_mouse
+                data.last_changed_anchor = 'selection_end'
+            else
+                data.caret_index = index_at_mouse
+                data.selection_start = index_at_mouse
+                data.selection_end = index_at_mouse
+                data.last_changed_anchor = 'caret'
+            end
         end
 
         -- If we're dragging the control, extend the existing selection.

--- a/src/ugui/controls/textbox.lua
+++ b/src/ugui/controls/textbox.lua
@@ -8,6 +8,47 @@
 ---@field public text string The text contained in the textbox.
 ---A textbox which can be edited.
 
+
+---Gets the index of the surrounding words in the specified text.
+---@param text string The text to search.
+---@param from integer The index to start searching from.
+---@return integer, integer The index of the surrounding words.
+local function surrounding_word_index(text, from)
+    local lo = 1
+    local hi = #text + 1
+
+    local function classify(c)
+        if c:match('%s') ~= nil then
+            return 'space'
+        end
+        if c:match('[%w_]') ~= nil then
+            return 'char'
+        end
+        return 'punct'
+    end
+
+    local initial_class = classify(text:sub(from, from))
+    local initial_class_lo = classify(text:sub(from - 1, from - 1))
+
+    for i = from - 1, 1, -1 do
+        local class = classify(text:sub(i, i))
+        if class ~= initial_class_lo then
+            lo = i + 1
+            break
+        end
+    end
+
+    for i = from, #text, 1 do
+        local class = classify(text:sub(i, i))
+        if class ~= initial_class then
+            hi = i
+            break
+        end
+    end
+
+    return lo, hi
+end
+
 ---@type ControlRegistryEntry
 ugui.registry.textbox = {
     ---@param control TextBox
@@ -76,24 +117,38 @@ ugui.registry.textbox = {
                             data.last_changed_anchor = 'caret'
                         end
                     elseif e.keycode == ugui.keycodes.VK_LEFT then
-                        if has_selection then
-                            data.selection_start = lower_selection
-                            data.selection_end = lower_selection
-                            data.caret_index = lower_selection
-                            data.last_changed_anchor = 'caret'
+                        if e.ctrl then
+                            local prev_word, _ = surrounding_word_index(data.text, data.caret_index)
+                            data.selection_start = prev_word
+                            data.selection_end = prev_word
+                            data.caret_index = prev_word
                         else
-                            data.caret_index = data.caret_index - 1
-                            data.last_changed_anchor = 'caret'
+                            if has_selection then
+                                data.selection_start = lower_selection
+                                data.selection_end = lower_selection
+                                data.caret_index = lower_selection
+                                data.last_changed_anchor = 'caret'
+                            else
+                                data.caret_index = data.caret_index - 1
+                                data.last_changed_anchor = 'caret'
+                            end
                         end
                     elseif e.keycode == ugui.keycodes.VK_RIGHT then
-                        if has_selection then
-                            data.selection_start = higher_selection
-                            data.selection_end = higher_selection
-                            data.caret_index = higher_selection
-                            data.last_changed_anchor = 'caret'
+                        if e.ctrl then
+                            local _, next_word = surrounding_word_index(data.text, data.caret_index)
+                            data.selection_start = next_word
+                            data.selection_end = next_word
+                            data.caret_index = next_word
                         else
-                            data.caret_index = data.caret_index + 1
-                            data.last_changed_anchor = 'caret'
+                            if has_selection then
+                                data.selection_start = higher_selection
+                                data.selection_end = higher_selection
+                                data.caret_index = higher_selection
+                                data.last_changed_anchor = 'caret'
+                            else
+                                data.caret_index = data.caret_index + 1
+                                data.last_changed_anchor = 'caret'
+                            end
                         end
                     end
 

--- a/src/ugui/controls/textbox.lua
+++ b/src/ugui/controls/textbox.lua
@@ -118,12 +118,14 @@ ugui.registry.textbox = {
                         end
                     elseif e.keycode == ugui.keycodes.VK_LEFT then
                         if e.ctrl then
-                            local prev_word, _ = surrounding_word_index(data.text, lower_selection)
-
                             if e.shift then
-                                data.selection_start = prev_word
+                                local prev_word, _ = surrounding_word_index(data.text, data.caret_index)
+                                local anchor = (data.caret_index == data.selection_end) and data.selection_start or data.selection_end
                                 data.caret_index = prev_word
+                                data.selection_start = math.min(anchor, prev_word)
+                                data.selection_end = math.max(anchor, prev_word)
                             else
+                                local prev_word, _ = surrounding_word_index(data.text, lower_selection)
                                 data.selection_start = prev_word
                                 data.selection_end = prev_word
                                 data.caret_index = prev_word
@@ -141,11 +143,14 @@ ugui.registry.textbox = {
                         end
                     elseif e.keycode == ugui.keycodes.VK_RIGHT then
                         if e.ctrl then
-                            local _, next_word = surrounding_word_index(data.text, higher_selection)
                             if e.shift then
-                                data.selection_end = next_word
+                                local _, next_word = surrounding_word_index(data.text, data.caret_index)
+                                local anchor = (data.caret_index == data.selection_start) and data.selection_end or data.selection_start
                                 data.caret_index = next_word
+                                data.selection_start = math.min(anchor, next_word)
+                                data.selection_end = math.max(anchor, next_word)
                             else
+                                local _, next_word = surrounding_word_index(data.text, higher_selection)
                                 data.selection_start = next_word
                                 data.selection_end = next_word
                                 data.caret_index = next_word

--- a/src/ugui/controls/textbox.lua
+++ b/src/ugui/controls/textbox.lua
@@ -101,6 +101,11 @@ ugui.registry.textbox = {
                         local selected_text = data.text:sub(lower_selection, higher_selection - 1)
                         ugui.STATIC_ENV.clipboard.set(selected_text)
                     end
+
+                    if e.keycode == ugui.keycodes.VK_A and e.ctrl then
+                        data.selection_start = 1
+                        data.selection_end = #data.text + 1
+                    end
                 end
 
                 if e.text then

--- a/src/ugui/environment/env.lua
+++ b/src/ugui/environment/env.lua
@@ -10,3 +10,4 @@
 ---@field public is_primary_down boolean? Whether the primary mouse button is being pressed.
 ---@field public key_events UguiKeyEventArgs[] The key events that happened since the last frame.
 ---@field public window_size { x: number, y: number }? The rendering bounds. If nil, no rendering bounds are considered and certain controls, such as menus, might overflow off-screen.
+---@field public shift boolean? Whether the shift key is being held down during this frame.


### PR DESCRIPTION
Enhances the selection behavior with various ergonomic optimizations borrowed from the Windows edit control.

New behavior:

<kbd>Ctrl</kbd> + <kbd>←</kbd> - Clear selection and move caret left one word
<kbd>Ctrl</kbd> + <kbd>→</kbd> - Clear selection and move caret right one word
<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>←</kbd> - Extend selection left one word
<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>→</kbd> - Extend selection right one word
<kbd>Shift</kbd> + LMB - Extend selection to clicked character

## Adoption

### `shift` in `environment` for `ugui.begin_frame` 

A per-frame `shift` modifier flag must be specified in the `environment` table provided to `ugui.begin_frame`.

Mupen64 Lua API users can adjust their code as follows:

```lua
local mup_input = input.get()
ugui.begin_frame({ ..., shift = mup_input.shift })
```