### PR TITLE
chore: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Read the [demo scripts](https://github.com/mupen64/ugui/tree/main/demos) for usa
 
 Can render using a built-in Windows 10-like style, or with ninesliced images.
 
-Depends on BreitbandGraphics for rendering.
+Depends on BreitbandGraphics for rendering, which is included in this repository as well ([see below](#breitbandgraphics)).
 
 ### Hackability
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,22 @@
 
 # 🚀 Quickstart
 
+Download `breitbandgraphics-amalgamated.lua` and `ugui-amalgamated.lua` from the latest [release](https://github.com/mupen64/ugui/releases)
+and place them anywhere in your repository. Then simply do the following in your main script file call `dofile` for them with their absolute file paths, for example:
+
 ```lua
+
+-- Get the directory where your entry script file is located (Windows, includes trailing backslash)
+folder = debug.getinfo(1).source:sub(2):match('(.*\\)')
+
 ---@module "breitbandgraphics-amalgamated"
-BreitbandGraphics = dofile('breitbandgraphics-amalgamated.lua')
+BreitbandGraphics = dofile(folder .. 'breitbandgraphics-amalgamated.lua')
 
 ---@module "ugui-amalgamated"
-ugui = dofile('ugui-amalgamated.lua')
+ugui = dofile(folder .. 'ugui-amalgamated.lua')
 ```
 
-That's it. Don't forget to pass an absolute path, not a relative one.
-
+That's it.  
 Read the [demo scripts](https://github.com/mupen64/ugui/tree/main/demos) for usage examples.
 
 # ✨ Features

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Flexible immediate-mode GUI library for Lua
 
 ## 🚀 Quickstart
 
-Download `breitbandgraphics-amalgamated.lua` and `ugui-amalgamated.lua` from the latest [release](https://github.com/mupen64/ugui/releases)
-and place them anywhere in your repository. Then simply do the following in your main script file call `dofile` for them with their absolute file paths, for example:
+Download `breitbandgraphics-amalgamated.lua` and `ugui-amalgamated.lua` from the latest [release](https://github.com/mupen64/ugui/releases/latest) and place them anywhere in your project.
+
+Then call `dofile` for them with their absolute paths:
 
 ```lua
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ ugui  —  The GUI library
 - `carrousel_button`
 - `combobox`
 - `joystick`
+- `label`
 - `listbox`
   - Scrolling support
   - Unlimited items with no performance degradation

--- a/README.md
+++ b/README.md
@@ -39,23 +39,23 @@ ugui  —  The GUI library
 ### Control Suite
 
 - `button`
-- `textbox`
-- `toggle_button`
 - `carrousel_button`
-- `trackbar`
 - `combobox`
+- `joystick`
 - `listbox`
   - Scrolling support
   - Unlimited items with no performance degradation
-- `scrollbar`
 - `menu`
   - Checkable items
+- `numberbox`
+- `scrollbar`
 - `spinner`
   - Optional negative/positive toggle
-- `numberbox`
 - `tabcontrol`
-- `joystick`
   - Adjustable magnitude circle 
+- `textbox`
+- `toggle_button`
+- `trackbar`
 
 ### Rendering
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,38 @@ Depends on BreitbandGraphics for rendering, which is included in this repository
 
 Any part of the library can be overwritten externally. Future compatibility not guaranteed.
 
+## 🛠️ Building from source
+
+The `breitbandgraphics-amalgamated.lua` and `ugui-amalgamated.lua` files are both built via the `build.py` python script.
+
+Requirements:
+- Python >= 3.9 ([official download site](https://www.python.org/downloads/))
+- git bash (as included in [Git for Windows](https://git-scm.com/install/windows))
+
+Build steps:
+1. Open a git bash, then clone the repository and navigate into the repository via the following command:
+```bash
+git clone https://github.com/mupen64/ugui.git && cd ./ugui
+```
+2. Create a python virtual environment and activate it:
+```bash
+python -m venv ./.venv
+source ./.venv/Scripts/activate
+```
+> Note: The second line must be executed in each new terminal session in order to build.
+
+3. Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+4. Run the build script:
+```
+python build.py
+```
+
+That's it.  
+`breitbandgraphics-amalgamated.lua` and `ugui-amalgamated.lua` should now have been created in the `./build/` directory.
+
 ---
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
   <img width="128" align="center" src="https://github.com/mupen64/ugui/blob/main/assets/ugui.png?raw=true">
 </p>
 
+<div align="center">
 
-<h1 align="center">
-  ugui
-</h1>
-<p align="center">
-  Flexible immediate-mode GUI library for Lua
-</p>
+# ugui
 
-# 🚀 Quickstart
+Flexible immediate-mode GUI library for Lua
+
+</div>
+
+## 🚀 Quickstart
 
 Download `breitbandgraphics-amalgamated.lua` and `ugui-amalgamated.lua` from the latest [release](https://github.com/mupen64/ugui/releases)
 and place them anywhere in your repository. Then simply do the following in your main script file call `dofile` for them with their absolute file paths, for example:
@@ -30,11 +30,7 @@ ugui = dofile(folder .. 'ugui-amalgamated.lua')
 That's it.  
 Read the [demo scripts](https://github.com/mupen64/ugui/tree/main/demos) for usage examples.
 
-# ✨ Features
-
-<img width="28" align="left" src="https://github.com/mupen64/ugui/blob/main/assets/ugui.png?raw=true">
-
-ugui  —  The GUI library
+## ✨ Features
 
 ### Control Suite
 
@@ -68,16 +64,24 @@ Depends on BreitbandGraphics for rendering.
 
 Any part of the library can be overwritten externally. Future compatibility not guaranteed.
 
-<img width="28" align="left" src="https://github.com/mupen64/ugui/blob/main/assets/breitbandgraphics.png?raw=true">
+---
 
-#
+<p align="center">
+  <img width="128" align="center" src="https://github.com/mupen64/ugui/blob/main/assets/breitbandgraphics.png?raw=true">
+</p>
 
-BreitbandGraphics  —  The rendering abstraction
+<div align="center">
 
-### Backends
+# BreitbandGraphics
+
+The rendering abstraction
+
+</div>
+
+## Backends
 
 Built-in backend for the [Mupen64](https://github.com/mupen64/mupen64-rr-lua) emulator.
 
-### Utilities
+## Utilities
 
 Provides various utilities for color conversion and manipulation.


### PR DESCRIPTION
This adjusts the readme to properly reflect the switch to the new build system, includes the `label` control, and fixes/adjusts the formatting of the headings.