### PR TITLE
fix(Styler): pass font params to compute_rich_text in draw_tooltip

### DIFF
--- a/src/ugui/styler.lua
+++ b/src/ugui/styler.lua
@@ -783,8 +783,8 @@ ugui.standard_styler = {
             return
         end
         local rectangle = {x = position.x, y = position.y, width = 0, height = 0}
-        local size = ugui.standard_styler.compute_rich_text(text, control.plaintext).size
-
+        local size = ugui.standard_styler.compute_rich_text(text, control.plaintext,
+        ugui.standard_styler.params.font_name, ugui.standard_styler.params.font_size).size
         rectangle.width = size.x
         rectangle.height = math.max(size.y, ugui.standard_styler.params.menu_item.height)
         rectangle.y = rectangle.y + rectangle.height


### PR DESCRIPTION
## Summary
  - Fix `draw_tooltip` crashing with `nil font_name` when hovering controls with tooltips
  - `draw_tooltip` was calling `compute_rich_text` without `font_name` and `font_size`, unlike
  `draw_rich_text` which properly defaults to `ugui.standard_styler.params`

  ## Fix
  Pass `font_name` and `font_size` from `ugui.standard_styler.params` to `compute_rich_text` in
  `draw_tooltip`.