### PR TITLE
feat(ComboBox)!: editing and filtering support

### DIFF
--- a/demos/overlapping_controls.lua
+++ b/demos/overlapping_controls.lua
@@ -25,14 +25,14 @@ emu.atdrawd2d(function()
         print('1')
     end
     if ugui.button({
-            uid = 10,
+            uid = 15,
             rectangle = {x = 80, y = 80, width = 100, height = 50},
             text = tostring(index),
         }) then
         index = index + 1
     end
     if ugui.button({
-            uid = 15,
+            uid = 25,
             rectangle = {x = 80, y = 140, width = 100, height = 30},
             text = 'Hello, world!',
             is_enabled = false,
@@ -40,48 +40,48 @@ emu.atdrawd2d(function()
         print('3')
     end
     checked = ugui.toggle_button({
-        uid = 20,
+        uid = 35,
         rectangle = {x = 80, y = 200, width = 200, height = 50},
         text = 'Hello, world!',
         is_checked = checked,
     })
     text = ugui.textbox({
-        uid = 25,
+        uid = 45,
         rectangle = {x = 20, y = 20, width = 100, height = 20},
         text = text,
     })
     position = ugui.joystick({
-        uid = 30,
+        uid = 55,
         rectangle = {x = 20, y = 200, width = 150, height = 150},
         position = position,
     })
 
     index = ugui.listbox({
-        uid = 40,
+        uid = 65,
         rectangle = {x = 20, y = 300, width = 120, height = 200},
         items = items,
         selected_index = index,
     })
     value = ugui.scrollbar({
-        uid = 45,
+        uid = 75,
         rectangle = {x = 230, y = 10, width = 20, height = 300},
         value = value,
         ratio = 0.2,
     })
     value = ugui.scrollbar({
-        uid = 46,
+        uid = 85,
         rectangle = {x = 280, y = 10, width = 300, height = 20},
         value = value,
         ratio = 0.2,
     })
     index = ugui.combobox({
-        uid = 50,
+        uid = 95,
         rectangle = {x = 200, y = 300, width = 160, height = 23},
         items = items,
         selected_index = index,
     })
     ugui.joystick({
-        uid = 55,
+        uid = 105,
         rectangle = {x = 200, y = 350, width = 150, height = 150},
         position = {
             x = math.sin(os.clock() / 2) * 50,
@@ -94,7 +94,7 @@ emu.atdrawd2d(function()
         },
     })
     ugui.joystick({
-        uid = 56,
+        uid = 115,
         rectangle = {x = 355, y = 350, width = 150, height = 150},
         position = {
             x = math.sin(os.clock() / 2) * 50,
@@ -102,14 +102,14 @@ emu.atdrawd2d(function()
         },
     })
     index = ugui.carrousel_button({
-        uid = 60,
+        uid = 125,
         rectangle = {x = 380, y = 300, width = 160, height = 23},
         items = items,
         selected_index = index,
     })
 
     num = ugui.numberbox({
-        uid = 65,
+        uid = 135,
         rectangle = {x = 350, y = 50, width = 160, height = 23},
         value = num,
         places = 4,
@@ -123,7 +123,7 @@ emu.atdrawd2d(function()
         font_size = ugui.standard_styler.params.font_size,
     })
     num2 = ugui.numberbox({
-        uid = 70,
+        uid = 145,
         rectangle = {x = 350, y = 75, width = 160, height = 23},
         value = num2,
         places = 4,
@@ -138,13 +138,19 @@ emu.atdrawd2d(function()
         font_size = ugui.standard_styler.params.font_size,
     })
     ugui.label({
-        uid = 75,
+        uid = 155,
         rectangle = {x = 350, y = 150, width = 160, height = 23},
         text = 'Hello World!',
         color = BreitbandGraphics.colors.black,
-        font_name = "Wingdings",
+        font_name = 'Wingdings',
         font_size = 24,
     })
-
+    index = ugui.combobox({
+        uid = 165,
+        rectangle = {x = 350, y = 230, width = 160, height = 23},
+        items = items,
+        selected_index = index,
+        editable = true,
+    })
     end_frame()
 end)

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -87,6 +87,7 @@ ugui.combobox = function(control)
                 width = control.rectangle.width - button_size,
                 height = control.rectangle.height,
             },
+            is_enabled = control.is_enabled,
             text = current_text,
         })
 
@@ -104,6 +105,7 @@ ugui.combobox = function(control)
                     width = button_size,
                     height = control.rectangle.height,
                 },
+                is_enabled = control.is_enabled,
                 text = data.open and '[icon:arrow_up]' or '[icon:arrow_down]',
             }) then
             data.open = not data.open

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -78,7 +78,7 @@ ugui.combobox = function(control)
     local button_size<const> = 30
 
     if control.editable then
-        local current_text = data.searching and data.search_text or control.items[data.selected_index]
+        local current_text = (data.searching and data.search_text or control.items[data.selected_index]) or ''
         local search_text = ugui.textbox({
             uid = textbox_uid,
             rectangle = {

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -110,87 +110,74 @@ ugui.combobox = function(control)
         end
     end
 
-    ---@type RichText[]
-    local filtered_items = {}
-
-    ---@type integer[] Maps filtered index -> original index
-    local filtered_to_original = {}
-
-    ---@type table<integer, integer> Maps original index -> filtered index
-    local original_to_filtered = {}
-
-    if data.searching then
-        for i, item in ipairs(control.items) do
-            if item:lower():find(data.search_text:lower(), 1, true) then
-                table.insert(filtered_items, item)
-                local filtered_index = #filtered_items
-                filtered_to_original[filtered_index] = i
-                original_to_filtered[i] = filtered_index
-            end
-        end
-    else
-        for i, item in ipairs(control.items) do
-            table.insert(filtered_items, item)
-            filtered_to_original[i] = i
-            original_to_filtered[i] = i
-        end
-    end
-
-
-    -- If there's only one item, select it automatically.
-    if #filtered_items == 1 then
-        data.selected_index = filtered_to_original[1]
-        data.open = false
-    end
-
-    if #filtered_items == 0 then
-        data.open = false
-    end
-
     if data.open then
-        -- Swap out the items so the measurement is correct...
-        if data.searching then
+        local items_to_show = control.items
+        local filtered_to_original = nil
+
+        if control.editable and data.searching then
+            ---@type RichText[]
+            local filtered_items = {}
+
+            ---@type integer[]
+            filtered_to_original = {}
+
+            for i, item in ipairs(control.items) do
+                if item:lower():find(data.search_text:lower(), 1, true) then
+                    table.insert(filtered_items, item)
+                    local filtered_index = #filtered_items
+                    filtered_to_original[filtered_index] = i
+                end
+            end
+
+            if #filtered_items == 1 then
+                data.selected_index = filtered_to_original[1]
+                data.open = false
+            end
+
+            if #filtered_items == 0 then
+                data.open = false
+            end
+
+            items_to_show = filtered_items
             control.items = filtered_items
         end
-        local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
 
-        local width = control.rectangle.width
-        if control.rectangle.x + width > ugui.internal.environment.window_size.x then
-            width = ugui.internal.environment.window_size.x - control.rectangle.x
-        end
+        if data.open then
+            local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
 
-        local height = content_bounds.height
-        if control.rectangle.y + height > ugui.internal.environment.window_size.y then
-            height = ugui.internal.environment.window_size.y - control.rectangle.y -
-                ugui.standard_styler.params.listbox_item.height * 2
-        end
+            local width = control.rectangle.width
+            if control.rectangle.x + width > ugui.internal.environment.window_size.x then
+                width = ugui.internal.environment.window_size.x - control.rectangle.x
+            end
 
-        local list_rect = {
-            x = control.rectangle.x,
-            y = control.rectangle.y + control.rectangle.height,
-            width = width,
-            height = height,
-        }
+            local height = content_bounds.height
+            if control.rectangle.y + height > ugui.internal.environment.window_size.y then
+                height = ugui.internal.environment.window_size.y - control.rectangle.y -
+                    ugui.standard_styler.params.listbox_item.height * 2
+            end
 
-        local filtered_selected = original_to_filtered[data.selected_index]
-        if filtered_selected == nil and #filtered_items > 0 then
-            filtered_selected = 1
-        end
+            local list_rect = {
+                x = control.rectangle.x,
+                y = control.rectangle.y + control.rectangle.height,
+                width = width,
+                height = height,
+            }
 
-        local listbox_result, meta_listbox = ugui.listbox({
-            uid = listbox_uid,
-            rectangle = list_rect,
-            items = filtered_items,
-            selected_index = filtered_selected,
-            plaintext = control.plaintext,
-            z_index = math.maxinteger,
-        })
+            local listbox_result, meta_listbox = ugui.listbox({
+                uid = listbox_uid,
+                rectangle = list_rect,
+                items = items_to_show,
+                selected_index = data.selected_index,
+                plaintext = control.plaintext,
+                z_index = math.maxinteger,
+            })
 
-        if meta_listbox.signal_change == ugui.signal_change_states.started then
-            data.selected_index = filtered_to_original[listbox_result]
-            data.searching = false
-            data.search_text = ''
-            data.open = false
+            if meta_listbox.signal_change == ugui.signal_change_states.started then
+                data.selected_index = filtered_to_original and filtered_to_original[listbox_result] or listbox_result
+                data.searching = false
+                data.search_text = ''
+                data.open = false
+            end
         end
     end
 

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -1,4 +1,3 @@
---
 -- Copyright (c) 2026, Mupen64 maintainers.
 --
 -- SPDX-License-Identifier: GPL-3.0-or-later
@@ -7,6 +6,7 @@
 ---@class ComboBox : Control
 ---@field public items RichText[] The items contained in the control.
 ---@field public selected_index integer? The index of the currently selected item into the items array. If nil, no item is selected.
+---@field public editable boolean? Whether the user can type in the combobox to filter the items.
 ---A combobox which allows the user to choose from a list of items.
 
 ---@type ControlRegistryEntry
@@ -18,12 +18,10 @@ ugui.registry.combobox = {
     end,
     ---@param control ComboBox
     setup = function(control, data)
-        if data.open == nil then
-            data.open = false
-        end
-        if data.hovered_index == nil then
-            data.hovered_index = control.selected_index
-        end
+        data.open = false
+        data.hovered_index = control.selected_index
+        data.searching = false
+        data.search_text = ''
     end,
     ---@param control ComboBox
     ---@return ControlReturnValue
@@ -34,7 +32,8 @@ ugui.registry.combobox = {
             data.open = false
         end
 
-        if ugui.internal.clicked_control == control.uid then
+        -- Only toggle on click if NOT editable (editable mode handles this via the button)
+        if not control.editable and ugui.internal.clicked_control == control.uid then
             data.open = not data.open
         end
 
@@ -55,7 +54,7 @@ ugui.registry.combobox = {
 
         return {
             primary = data.selected_index,
-            meta = { signal_change = data.signal_change },
+            meta = {signal_change = data.signal_change},
         }
     end,
     ---@param control ComboBox
@@ -72,7 +71,87 @@ ugui.combobox = function(control)
     local result = ugui.control(control, 'combobox')
     local data = ugui.internal.control_data[control.uid]
 
+    local textbox_uid<const> = control.uid + 1
+    local button_uid<const> = control.uid + 2
+    local listbox_uid<const> = control.uid + 3
+
+    local button_size<const> = 30
+
+    if control.editable then
+        local current_text = data.searching and data.search_text or control.items[data.selected_index]
+        local search_text = ugui.textbox({
+            uid = textbox_uid,
+            rectangle = {
+                x = control.rectangle.x,
+                y = control.rectangle.y,
+                width = control.rectangle.width - button_size,
+                height = control.rectangle.height,
+            },
+            text = current_text,
+        })
+
+        if search_text ~= current_text then
+            data.searching = true
+            data.open = true
+            data.search_text = search_text
+        end
+
+        if ugui.button({
+                uid = button_uid,
+                rectangle = {
+                    x = control.rectangle.x + control.rectangle.width - button_size,
+                    y = control.rectangle.y,
+                    width = button_size,
+                    height = control.rectangle.height,
+                },
+                text = data.open and '[icon:arrow_up]' or '[icon:arrow_down]',
+            }) then
+            data.open = not data.open
+        end
+    end
+
+    ---@type RichText[]
+    local filtered_items = {}
+
+    ---@type integer[] Maps filtered index -> original index
+    local filtered_to_original = {}
+
+    ---@type table<integer, integer> Maps original index -> filtered index
+    local original_to_filtered = {}
+
+    if data.searching then
+        for i, item in ipairs(control.items) do
+            if item:lower():find(data.search_text:lower(), 1, true) then
+                table.insert(filtered_items, item)
+                local filtered_index = #filtered_items
+                filtered_to_original[filtered_index] = i
+                original_to_filtered[i] = filtered_index
+            end
+        end
+    else
+        for i, item in ipairs(control.items) do
+            table.insert(filtered_items, item)
+            filtered_to_original[i] = i
+            original_to_filtered[i] = i
+        end
+    end
+
+
+    -- If there's only one item, select it automatically.
+    if #filtered_items == 1 then
+        data.selected_index = filtered_to_original[1]
+        data.open = false
+    end
+
+    if #filtered_items == 0 then
+        data.open = false
+    end
+
     if data.open then
+        -- Swap out the items so the measurement is correct...
+        if data.searching then
+            control.items = filtered_items
+        end
         local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
 
         local width = control.rectangle.width
@@ -93,14 +172,26 @@ ugui.combobox = function(control)
             height = height,
         }
 
-        data.selected_index = ugui.listbox({
-            uid = control.uid + 1,
+        local filtered_selected = original_to_filtered[data.selected_index]
+        if filtered_selected == nil and #filtered_items > 0 then
+            filtered_selected = 1
+        end
+
+        local listbox_result, meta_listbox = ugui.listbox({
+            uid = listbox_uid,
             rectangle = list_rect,
-            items = control.items,
-            selected_index = data.selected_index,
+            items = filtered_items,
+            selected_index = filtered_selected,
             plaintext = control.plaintext,
             z_index = math.maxinteger,
         })
+
+        if meta_listbox.signal_change == ugui.signal_change_states.started then
+            data.selected_index = filtered_to_original[listbox_result]
+            data.searching = false
+            data.search_text = ''
+            data.open = false
+        end
     end
 
     return data.selected_index, result.meta


### PR DESCRIPTION
Adds editing and filtering support to `combobox`. Can be enabled for comboboxes via the `editable` field.

## Breaking Changes

### `combobox` reserves 5 UID slots

The `combobox` control now reserves 5 UID slots instead of 3.

Adjust your code accordingly if you use sequential UIDs.