### PR TITLE
feat(label): make labels non-hittestable by default

### DIFF
--- a/demos/overlapping_controls.lua
+++ b/demos/overlapping_controls.lua
@@ -19,7 +19,7 @@ emu.atdrawd2d(function()
 
     if ugui.button({
             uid = 5,
-            rectangle = {x = 10, y = 10, width = 200, height = 400},
+            rectangle = {x = 10, y = 10, width = 600, height = 400},
             text = 'Hello, world!',
         }) then
         print('1')
@@ -145,23 +145,32 @@ emu.atdrawd2d(function()
         font_name = 'Wingdings',
         font_size = 24,
     })
-    index = ugui.combobox({
+    ugui.label({
         uid = 165,
+        rectangle = {x = 350, y = 180, width = 160, height = 23},
+        text = 'Hello World!',
+        color = BreitbandGraphics.colors.black,
+        font_name = 'Consolas',
+        font_size = 24,
+        hittestable = true
+    })
+    index = ugui.combobox({
+        uid = 175,
         rectangle = {x = 350, y = 230, width = 160, height = 23},
         items = items,
         selected_index = index,
         editable = true,
     })
     ugui.listbox({
-        uid = 175,
+        uid = 185,
         rectangle = {x = 560, y = 230, width = 160, height = 160},
         items = {},
         selected_index = 1,
     })
     ugui.listbox({
-        uid = 185,
+        uid = 195,
         rectangle = {x = 560, y = 360, width = 160, height = 160},
-        items = {"a"},
+        items = {'a'},
         selected_index = nil,
     })
     end_frame()

--- a/src/ugui/controls/label.lua
+++ b/src/ugui/controls/label.lua
@@ -16,7 +16,7 @@
 ---@type ControlRegistryEntry
 ugui.registry.label = {
     hittestable = function(control)
-        return control.selectable == true
+        return false
     end,
     ---@param control Label
     validate = function(control)

--- a/src/ugui/controls/label.lua
+++ b/src/ugui/controls/label.lua
@@ -11,11 +11,14 @@
 ---@field public font_name string? The font family of the text. If `nil`, the default font family is used.
 ---@field public align_x Alignment? The text's horizontal alignment inside the control rectangle. If `nil`, `alignment.center` is assumed.
 ---@field public align_y Alignment? The text's vertical alignment inside the control rectangle. If `nil`, `alignment.center` is assumed.
+---@field public selectable boolean? Whether the label's text is selectable. If `true`, the label participates in hit-testing to allow text selection.
 ---A label that contains text.
 
 ---@type ControlRegistryEntry
 ugui.registry.label = {
-    interactive = false,
+    hittestable = function(control)
+        return control.selectable == true
+    end,
     ---@param control Label
     validate = function(control)
         ugui.internal.assert(type(control.text) == 'string', 'expected text to be string')

--- a/src/ugui/controls/label.lua
+++ b/src/ugui/controls/label.lua
@@ -11,7 +11,6 @@
 ---@field public font_name string? The font family of the text. If `nil`, the default font family is used.
 ---@field public align_x Alignment? The text's horizontal alignment inside the control rectangle. If `nil`, `alignment.center` is assumed.
 ---@field public align_y Alignment? The text's vertical alignment inside the control rectangle. If `nil`, `alignment.center` is assumed.
----@field public selectable boolean? Whether the label's text is selectable. If `true`, the label participates in hit-testing to allow text selection.
 ---A label that contains text.
 
 ---@type ControlRegistryEntry

--- a/src/ugui/controls/label.lua
+++ b/src/ugui/controls/label.lua
@@ -15,6 +15,7 @@
 
 ---@type ControlRegistryEntry
 ugui.registry.label = {
+    interactive = false,
     ---@param control Label
     validate = function(control)
         ugui.internal.assert(type(control.text) == 'string', 'expected text to be string')

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -10,8 +10,11 @@
 ---@field public added fun(control: Control, data: any)? Notifies about a control being added to a scene.
 ---@field public logic fun(control: Control, data: any): ControlReturnValue Executes control logic.
 ---@field public draw fun(control: Control) Draws the control.
----@field public interactive boolean? Whether the control can receive clicks and hover. If `false`, the control is transparent to input. Defaults to `true` if not specified.
+---@field public hittestable fun(control: Control): boolean? A function returning whether a control instance of this type should participate in hit-testing. If `nil`, the instance-level `hittestable` field is used. If both are `nil`, the control is hittestable.
 ---Represents an entry in the control registry.
+
+---@class Control
+---@field public hittestable boolean? Whether this control instance participates in hit-testing. Overrides the registry-level `hittestable` function if specified. Defaults to `true` if neither this nor the registry function is set.
 
 ---@alias UID number
 ---Unique identifier for a control. Must be unique within a frame.

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -10,6 +10,7 @@
 ---@field public added fun(control: Control, data: any)? Notifies about a control being added to a scene.
 ---@field public logic fun(control: Control, data: any): ControlReturnValue Executes control logic.
 ---@field public draw fun(control: Control) Draws the control.
+---@field public interactive boolean? Whether the control can receive clicks and hover. If `false`, the control is transparent to input. Defaults to `true` if not specified.
 ---Represents an entry in the control registry.
 
 ---@alias UID number

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -293,6 +293,15 @@ ugui.internal = {
                 point.y <= rectangle.y + rectangle.height
         end
 
+        local function compute_effective_hittestable(control, registry_entry)
+            if control.hittestable ~= nil then
+                return control.hittestable
+            elseif registry_entry.hittestable ~= nil then
+                return registry_entry.hittestable(control)
+            end
+            return true
+        end
+
         ---@type Control?
         local clicked_control = nil
 
@@ -323,18 +332,7 @@ ugui.internal = {
             local control = entry.control
             local registry_entry = ugui.registry[entry.type]
 
-            -- Compute effective hittestability:
-            -- 1. Instance-level override takes priority if specified.
-            -- 2. Otherwise, the registry-level function is called if present.
-            -- 3. Defaults to true if neither is specified.
-            local effective_hittestable
-            if control.hittestable ~= nil then
-                effective_hittestable = control.hittestable
-            elseif registry_entry.hittestable ~= nil then
-                effective_hittestable = registry_entry.hittestable(control)
-            else
-                effective_hittestable = true
-            end
+            local effective_hittestable = compute_effective_hittestable(control, registry_entry)
 
             -- Determine the clicked control if we haven't already
             if clicked_control == nil and effective_hittestable then

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -323,8 +323,21 @@ ugui.internal = {
             local control = entry.control
             local registry_entry = ugui.registry[entry.type]
 
+            -- Compute effective hittestability:
+            -- 1. Instance-level override takes priority if specified.
+            -- 2. Otherwise, the registry-level function is called if present.
+            -- 3. Defaults to true if neither is specified.
+            local effective_hittestable
+            if control.hittestable ~= nil then
+                effective_hittestable = control.hittestable
+            elseif registry_entry.hittestable ~= nil then
+                effective_hittestable = registry_entry.hittestable(control)
+            else
+                effective_hittestable = true
+            end
+
             -- Determine the clicked control if we haven't already
-            if clicked_control == nil and registry_entry.interactive ~= false then
+            if clicked_control == nil and effective_hittestable then
                 if ugui.internal.is_mouse_just_down() then
                     if is_point_inside_rectangle(ugui.internal.mouse_down_position, control.rectangle) then
                         clicked_control = control
@@ -335,7 +348,7 @@ ugui.internal = {
             end
 
             -- Determine the hovered control if we haven't already
-            if ugui.internal.hovered_control == nil and registry_entry.interactive ~= false then
+            if ugui.internal.hovered_control == nil and effective_hittestable then
                 if is_point_inside_rectangle(ugui.internal.environment.mouse_position, control.rectangle) then
                     ugui.internal.hovered_control = control.uid
 

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -284,6 +284,22 @@ ugui.internal = {
         return segments
     end,
 
+    ---Computes the effective value of a control property, respecting instance-level
+    ---overrides, registry-level defaults, and a fallback default.
+    ---@param control Control
+    ---@param registry_entry ControlRegistryEntry
+    ---@param prop_name string
+    ---@param get_default fun(): any
+    ---@return any
+    compute_prop = function(control, registry_entry, prop_name, get_default)
+        if control[prop_name] ~= nil then
+            return control[prop_name]
+        elseif registry_entry[prop_name] ~= nil then
+            return registry_entry[prop_name](control)
+        end
+        return get_default()
+    end,
+
     ---Does core input processing work, such as control capture/hover/click state management.
     do_input_processing = function()
         local function is_point_inside_rectangle(point, rectangle)
@@ -291,15 +307,6 @@ ugui.internal = {
                 point.y >= rectangle.y and
                 point.x <= rectangle.x + rectangle.width and
                 point.y <= rectangle.y + rectangle.height
-        end
-
-        local function compute_effective_hittestable(control, registry_entry)
-            if control.hittestable ~= nil then
-                return control.hittestable
-            elseif registry_entry.hittestable ~= nil then
-                return registry_entry.hittestable(control)
-            end
-            return true
         end
 
         ---@type Control?
@@ -332,7 +339,7 @@ ugui.internal = {
             local control = entry.control
             local registry_entry = ugui.registry[entry.type]
 
-            local effective_hittestable = compute_effective_hittestable(control, registry_entry)
+            local effective_hittestable = ugui.internal.compute_prop(control, registry_entry, 'hittestable', function() return true end)
 
             -- Determine the clicked control if we haven't already
             if clicked_control == nil and effective_hittestable then

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -321,9 +321,10 @@ ugui.internal = {
         for i = #ugui.internal.scene, 1, -1 do
             local entry = ugui.internal.scene[i]
             local control = entry.control
+            local registry_entry = ugui.registry[entry.type]
 
             -- Determine the clicked control if we haven't already
-            if clicked_control == nil then
+            if clicked_control == nil and registry_entry.interactive ~= false then
                 if ugui.internal.is_mouse_just_down() then
                     if is_point_inside_rectangle(ugui.internal.mouse_down_position, control.rectangle) then
                         clicked_control = control
@@ -334,7 +335,7 @@ ugui.internal = {
             end
 
             -- Determine the hovered control if we haven't already
-            if ugui.internal.hovered_control == nil then
+            if ugui.internal.hovered_control == nil and registry_entry.interactive ~= false then
                 if is_point_inside_rectangle(ugui.internal.environment.mouse_position, control.rectangle) then
                     ugui.internal.hovered_control = control.uid
 


### PR DESCRIPTION
## Problem

  `ugui.label` is added to the scene like any interactive control. The input
  processing loop in `do_input_processing` iterates the scene in reverse and
  assigns the first control whose rectangle contains the click/hover position as
  `clicked_control`/`hovered_control`, without distinguishing interactive controls
  from non-interactive ones.

  This means a label whose rectangle overlaps a button will silently steal clicks
  and hover state from it, causing the button to never fire.

  This was discovered in a project using ugui where a `ugui.label` placed after a
  `ugui.button` in the same render pass overlapped the button's rectangle. The
  button became completely unresponsive because the label was higher in the scene
  and consumed the click first.

  ## Fix

  Add an `interactive = false` field to `ugui.registry.label`. The input processing
  loop now checks `registry_entry.interactive ~= false` before considering a control
  as a candidate for `clicked_control` or `hovered_control`.

  The `interactive` field is also documented in `ControlRegistryEntry` so any future
  non-interactive control type just needs to declare `interactive = false` in its
  registry entry, with no changes needed to the input processing logic.
  
## Note 
  An alternative approach would be to add a `hittest_visible` field at the **instance**                           level (`Control`) rather than at the registry level (`ControlRegistryEntry`), and check
  it inside `is_point_inside_control`, which already mentions "hittest-free" regions in
  its docstring but never implements it.

  The difference:
  - **This PR** (registry level) — all labels are unconditionally non-interactive
  - **Instance level** — individual controls could opt out of hit-testing per instance

  Both approaches fix the bug. The instance-level approach would integrate more naturally
  with the existing `is_point_inside_control` design intent, but requires more changes.
  Happy to update this PR if you prefer that direction.
  
  ## Bug
 This bug was introduced by a472c8f in the downstream project SM64LuaRedux, a refactor                           that replaced direct `BreitbandGraphics` text drawing calls with `ugui.label`. Before
that change, text was drawn outside of the ugui scene and had no impact on input                                processing. After the refactor, labels entered the scene and started silently stealing
clicks from underlying buttons without any warning or error.

  [https://github.com/mupen64/SM64LuaRedux/commit/a472c8fbadbca566ef62bb01d66733f698a10826](url)