### PR TITLE
feat(combobox): keyboard support for `editable` and configurable signal and selected index change behavior

### DIFF
--- a/demos/interaction_state.lua
+++ b/demos/interaction_state.lua
@@ -1,11 +1,12 @@
 local path_root = debug.getinfo(1).source:sub(2):gsub('\\[^\\]+\\[^\\]+$', '\\') .. 'demos\\'
 dofile(path_root .. 'base.lua')
 
-local interaction_logs = { 'none' }
+local interaction_logs = {'none'}
 local items = {}
 local checked = true
 local index = 1
-local combobox_selected_index = 1
+local combobox1_selected_index = 1
+local combobox2_selected_index = 1
 
 for i = 1, 100, 1 do
     items[#items + 1] = 'Item ' .. i
@@ -23,7 +24,7 @@ local function log_interaction(meta, value)
     elseif meta.signal_change == ugui.signal_change_states.ended then
         text_interaction = 'ended, finally'
     end
-    text_interaction = text_interaction .. "(" .. tostring(value) .. ")"
+    text_interaction = text_interaction .. '(' .. tostring(value) .. ')'
     if interaction_logs[#interaction_logs] == text_interaction then
         return
     end
@@ -66,14 +67,40 @@ emu.atdrawd2d(function()
         uid = 25,
         rectangle = {x = 350, y = 40, width = 100, height = 30},
         items = {'One', 'Two which is very long', 'Three', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More'},
-        selected_index = combobox_selected_index,
+        selected_index = combobox1_selected_index,
         editable = true,
         preview_change = true,
     })
     if meta.signal_change == ugui.signal_change_states.ended then
-        combobox_selected_index = new_index
+        combobox1_selected_index = new_index
     end
+    ugui.label({
+        uid = 40,
+        rectangle = {x = 460, y = 40, width = 100, height = 30},
+        text = 'Selected index: ' .. combobox1_selected_index .. ', immediate ' .. tostring(new_index),
+        color = {r = 0, g = 0, b = 0},
+        align_x = BreitbandGraphics.alignment.start,
+    })
     log_interaction(meta, new_index)
+
+    local new_index2, meta = ugui.combobox({
+        uid = 60,
+        rectangle = {x = 350, y = 80, width = 100, height = 30},
+        items = {'One', 'Two which is very long', 'Three', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More'},
+        selected_index = combobox2_selected_index,
+        editable = true,
+    })
+    if meta.signal_change == ugui.signal_change_states.ended then
+        combobox2_selected_index = new_index2
+    end
+    ugui.label({
+        uid = 80,
+        rectangle = {x = 460, y = 80, width = 100, height = 30},
+        text = 'Selected index: ' .. combobox2_selected_index .. ', immediate ' .. tostring(new_index2),
+        color = {r = 0, g = 0, b = 0},
+        align_x = BreitbandGraphics.alignment.start,
+    })
+    log_interaction(meta, new_index2)
 
     end_frame()
 end)

--- a/demos/interaction_state.lua
+++ b/demos/interaction_state.lua
@@ -1,17 +1,18 @@
 local path_root = debug.getinfo(1).source:sub(2):gsub('\\[^\\]+\\[^\\]+$', '\\') .. 'demos\\'
 dofile(path_root .. 'base.lua')
 
-local interaction_logs = {}
+local interaction_logs = { 'none' }
 local items = {}
 local checked = true
 local index = 1
+local combobox_selected_index = 1
 
 for i = 1, 100, 1 do
     items[#items + 1] = 'Item ' .. i
 end
 
 ---@param meta Meta
-local function log_interaction(meta)
+local function log_interaction(meta, value)
     local text_interaction
     if meta.signal_change == ugui.signal_change_states.none then
         text_interaction = 'none'
@@ -20,8 +21,9 @@ local function log_interaction(meta)
     elseif meta.signal_change == ugui.signal_change_states.ongoing then
         text_interaction = 'ongoing'
     elseif meta.signal_change == ugui.signal_change_states.ended then
-        text_interaction = 'ended'
+        text_interaction = 'ended, finally'
     end
+    text_interaction = text_interaction .. "(" .. tostring(value) .. ")"
     if interaction_logs[#interaction_logs] == text_interaction then
         return
     end
@@ -36,6 +38,7 @@ emu.atdrawd2d(function()
         rectangle = {x = 10, y = 40, width = 100, height = 200},
         items = interaction_logs,
         selected_index = nil,
+        horizontal_scroll = true,
     })
 
     local pressed, meta = ugui.button({
@@ -58,7 +61,19 @@ emu.atdrawd2d(function()
         items = items,
         selected_index = index,
     })
-    log_interaction(meta)
+
+    local new_index, meta = ugui.combobox({
+        uid = 25,
+        rectangle = {x = 350, y = 40, width = 100, height = 30},
+        items = {'One', 'Two which is very long', 'Three', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More', 'More'},
+        selected_index = combobox_selected_index,
+        editable = true,
+        preview_change = true,
+    })
+    if meta.signal_change == ugui.signal_change_states.ended then
+        combobox_selected_index = new_index
+    end
+    log_interaction(meta, new_index)
 
     end_frame()
 end)

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -38,6 +38,17 @@ ugui.registry.combobox = {
             data.open = not data.open
         end
 
+        if data.open then
+            -- allow confirming the selection with return when the control itself or the textbox captures keyboard input
+            if ugui.internal.keyboard_captured_control == control.uid + (control.editable and 1 or 0) then
+                for _, e in ipairs(ugui.internal.environment.key_events) do
+                    if e.keycode == ugui.keycodes.VK_RETURN and e.pressed then
+                        data.close_on_next_update = true
+                    end
+                end
+            end
+        end
+
         local selected_index = data.filtered_to_original and data.filtered_to_original[data.selected_index] or data.selected_index
 
         local signal_change = control.selected_index ~= selected_index
@@ -170,6 +181,8 @@ ugui.combobox = function(control)
                 height = height,
             }
 
+            local restore = ugui.internal.keyboard_captured_control
+            ugui.internal.keyboard_captured_control = listbox_uid
             data.selected_index = ugui.listbox({
                 uid = listbox_uid,
                 rectangle = list_rect,
@@ -178,6 +191,7 @@ ugui.combobox = function(control)
                 plaintext = control.plaintext,
                 z_index = math.maxinteger,
             })
+            ugui.internal.keyboard_captured_control = restore
 
             if data.close_on_next_update then
                 data.open = false

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -22,6 +22,7 @@ ugui.registry.combobox = {
         data.open = false
         data.was_open = false
         data.selected_index = control.selected_index
+        data.quiet_selected_index = control.selected_index
         data.update_filter = false
         data.search_text = nil
         data.close_on_next_update = false
@@ -121,12 +122,14 @@ ugui.combobox = function(control)
             data.open = not data.open
             data.update_filter = data.open
             data.search_text = current_text
+            data.quiet_selected_index = 1
         end
 
         if search_text ~= current_text then
             data.update_filter = true
             data.open = true
             data.search_text = search_text
+            data.quiet_selected_index = 1
         end
     end
 
@@ -183,11 +186,11 @@ ugui.combobox = function(control)
 
             local restore = ugui.internal.keyboard_captured_control
             ugui.internal.keyboard_captured_control = listbox_uid
-            data.selected_index = ugui.listbox({
+            data.quiet_selected_index = ugui.listbox({
                 uid = listbox_uid,
                 rectangle = list_rect,
                 items = items_to_show,
-                selected_index = data.selected_index,
+                selected_index = data.quiet_selected_index,
                 plaintext = control.plaintext,
                 z_index = math.maxinteger,
             })
@@ -196,6 +199,8 @@ ugui.combobox = function(control)
             if data.close_on_next_update then
                 data.open = false
                 data.search_text = nil
+                -- Commit the selection
+                data.selected_index = data.filtered_to_original and data.filtered_to_original[data.quiet_selected_index] or data.quiet_selected_index
             end
 
             data.close_on_next_update =

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -11,6 +11,7 @@
 
 ---@type ControlRegistryEntry
 ugui.registry.combobox = {
+    hittestable = nil,
     ---@param control ComboBox
     validate = function(control)
         ugui.internal.assert(type(control.items) == 'table', 'expected items to be table')
@@ -19,15 +20,15 @@ ugui.registry.combobox = {
     ---@param control ComboBox
     setup = function(control, data)
         data.open = false
-        data.hovered_index = control.selected_index
-        data.searching = false
-        data.search_text = ''
+        data.was_open = false
+        data.selected_index = control.selected_index
+        data.update_filter = false
+        data.search_text = nil
+        data.close_on_next_update = false
     end,
     ---@param control ComboBox
     ---@return ControlReturnValue
     logic = function(control, data)
-        data.selected_index = control.selected_index
-
         if control.is_enabled == false then
             data.open = false
         end
@@ -37,24 +38,27 @@ ugui.registry.combobox = {
             data.open = not data.open
         end
 
-        if data.open and ugui.internal.is_mouse_just_down() and not ugui.internal.is_point_inside_control(ugui.internal.environment.mouse_position, control) then
-            local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
-            if not BreitbandGraphics.is_point_inside_rectangle(ugui.internal.environment.mouse_position, {
-                    x = control.rectangle.x,
-                    y = control.rectangle.y + control.rectangle.height,
-                    width = control.rectangle.width,
-                    height = content_bounds.height,
-                }) then
-                data.open = false
+        local selected_index = data.filtered_to_original and data.filtered_to_original[data.selected_index] or data.selected_index
+
+        local signal_change = control.selected_index ~= selected_index
+            and (data.open
+                and (data.was_open and ugui.signal_change_states.ongoing or ugui.signal_change_states.started)
+                or (data.was_open and ugui.signal_change_states.ended or ugui.signal_change_states.none))
+            or ugui.signal_change_states.none
+
+        if signal_change == ugui.signal_change_states.ended then
+            data.searching = false
+            data.search_text = nil
+        elseif signal_change == ugui.signal_change_states.none then
+            selected_index = control.selected_index
+            if not control.editable then
+                data.selected_index = selected_index
             end
         end
-
-        data.signal_change = ugui.internal.process_signal_changes(data.signal_change,
-            control.selected_index ~= data.selected_index)
-
+        data.was_open = data.open
         return {
-            primary = data.selected_index,
-            meta = {signal_change = data.signal_change},
+            primary = selected_index,
+            meta = {signal_change = signal_change},
         }
     end,
     ---@param control ComboBox
@@ -78,7 +82,8 @@ ugui.combobox = function(control)
     local button_size<const> = 30
 
     if control.editable then
-        local current_text = (data.searching and data.search_text or control.items[data.selected_index]) or ''
+        local selected_index = data.filtered_to_original and data.filtered_to_original[data.selected_index] or data.selected_index
+        local current_text = (data.search_text or control.items[selected_index]) or ''
         local search_text = ugui.textbox({
             uid = textbox_uid,
             rectangle = {
@@ -90,12 +95,6 @@ ugui.combobox = function(control)
             is_enabled = control.is_enabled,
             text = current_text,
         })
-
-        if search_text ~= current_text then
-            data.searching = true
-            data.open = true
-            data.search_text = search_text
-        end
 
         if ugui.button({
                 uid = button_uid,
@@ -109,39 +108,45 @@ ugui.combobox = function(control)
                 text = data.open and '[icon:arrow_up]' or '[icon:arrow_down]',
             }) then
             data.open = not data.open
+            data.update_filter = data.open
+            data.search_text = current_text
+        end
+
+        if search_text ~= current_text then
+            data.update_filter = true
+            data.open = true
+            data.search_text = search_text
         end
     end
 
     if data.open then
         local items_to_show = control.items
-        local filtered_to_original = nil
 
-        if control.editable and data.searching then
-            ---@type RichText[]
-            local filtered_items = {}
+        if control.editable then
+            if data.update_filter then
+                data.update_filter = false
+                ---@type RichText[]
+                data.filtered_items = {}
 
-            ---@type integer[]
-            filtered_to_original = {}
+                ---@type integer[]
+                data.filtered_to_original = {}
 
-            for i, item in ipairs(control.items) do
-                if item:lower():find(data.search_text:lower(), 1, true) then
-                    table.insert(filtered_items, item)
-                    local filtered_index = #filtered_items
-                    filtered_to_original[filtered_index] = i
+                for i, item in ipairs(control.items) do
+                    if item:lower():find(data.search_text:lower(), 1, true) then
+                        table.insert(data.filtered_items, item)
+                        local filtered_index = #data.filtered_items
+                        data.filtered_to_original[filtered_index] = i
+                        if control.selected_index == i then
+                            data.selected_index = filtered_index
+                        end
+                    end
                 end
             end
 
-            if #filtered_items == 1 then
-                data.selected_index = filtered_to_original[1]
-                data.open = false
-            end
-
-            if #filtered_items == 0 then
-                data.open = false
-            end
-
-            items_to_show = filtered_items
-            control.items = filtered_items
+            items_to_show = data.filtered_items
+            control.items = data.filtered_items
+        else
+            data.filtered_to_original = nil
         end
 
         if data.open then
@@ -165,7 +170,7 @@ ugui.combobox = function(control)
                 height = height,
             }
 
-            local listbox_result, meta_listbox = ugui.listbox({
+            data.selected_index = ugui.listbox({
                 uid = listbox_uid,
                 rectangle = list_rect,
                 items = items_to_show,
@@ -174,14 +179,17 @@ ugui.combobox = function(control)
                 z_index = math.maxinteger,
             })
 
-            if meta_listbox.signal_change == ugui.signal_change_states.started then
-                data.selected_index = filtered_to_original and filtered_to_original[listbox_result] or listbox_result
-                data.searching = false
-                data.search_text = ''
+            if data.close_on_next_update then
                 data.open = false
+                data.search_text = nil
             end
+
+            data.close_on_next_update =
+                data.open
+                and ugui.internal.is_mouse_just_down()
+                and not ugui.internal.is_point_inside_control(ugui.internal.environment.mouse_position, control)
         end
     end
 
-    return data.selected_index, result.meta
+    return result.primary, result.meta
 end

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -76,6 +76,9 @@ ugui.combobox = function(control)
     local button_uid<const> = control.uid + 2
     local listbox_uid<const> = control.uid + 3
 
+    -- listbox_uid + 2 for the scrollbars
+    local highest_owned_uid<const> = control.uid + 5
+
     local button_size<const> = 30
 
     if control.editable then
@@ -170,7 +173,7 @@ ugui.combobox = function(control)
         ugui.internal.keyboard_captured_control = listbox_uid
         local listbox = {
             uid = listbox_uid,
-            rectangle = ugui.internal.deep_clone(list_rect),
+            rectangle = list_rect,
             items = items_to_show,
             selected_index = data.selected_index,
             plaintext = control.plaintext,
@@ -183,7 +186,7 @@ ugui.combobox = function(control)
         local enter_pressed = false
         -- allow confirming the selection with return when any of the owned controls captures keyboard input
         if ugui.internal.keyboard_captured_control >= control.uid
-            and ugui.internal.keyboard_captured_control <= listbox_uid
+            and ugui.internal.keyboard_captured_control <= highest_owned_uid
         then
             for _, e in ipairs(ugui.internal.environment.key_events) do
                 if e.keycode == ugui.keycodes.VK_RETURN and e.pressed then
@@ -197,15 +200,7 @@ ugui.combobox = function(control)
         local released_inside = ugui.internal.is_mouse_just_up() and in_listbox
         local clicked_outside =
             ugui.internal.is_mouse_just_down()
-            and not (
-                    in_listbox
-                    or ugui.internal.is_point_inside_control(ugui.internal.environment.mouse_position, control)
-                    or (-- weird hack to discover whether the user intends to scroll:
-                        -- this works because the listbox logic mutates its rectangle to be smaller if it spawns a scrollbar
-                        BreitbandGraphics.is_point_inside_rectangle(ugui.internal.environment.mouse_position, list_rect)
-                        and not in_listbox
-                        )
-                    )
+            and (ugui.internal.hovered_control < control.uid or ugui.internal.hovered_control > highest_owned_uid)
 
         if enter_pressed or released_inside or clicked_outside then
             data.open = false

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -22,10 +22,8 @@ ugui.registry.combobox = {
         data.open = false
         data.was_open = false
         data.selected_index = control.selected_index
-        data.quiet_selected_index = control.selected_index
         data.update_filter = false
         data.search_text = nil
-        data.close_on_next_update = false
     end,
     ---@param control ComboBox
     ---@return ControlReturnValue
@@ -61,11 +59,6 @@ ugui.registry.combobox = {
         if signal_change == ugui.signal_change_states.ended then
             data.searching = false
             data.search_text = nil
-        elseif signal_change == ugui.signal_change_states.none then
-            selected_index = control.selected_index
-            if not control.editable then
-                data.selected_index = selected_index
-            end
         end
         data.was_open = data.open
         return {
@@ -122,14 +115,12 @@ ugui.combobox = function(control)
             data.open = not data.open
             data.update_filter = data.open
             data.search_text = current_text
-            data.quiet_selected_index = 1
         end
 
         if search_text ~= current_text then
             data.update_filter = true
             data.open = true
             data.search_text = search_text
-            data.quiet_selected_index = 1
         end
     end
 
@@ -185,27 +176,41 @@ ugui.combobox = function(control)
 
         local restore = ugui.internal.keyboard_captured_control
         ugui.internal.keyboard_captured_control = listbox_uid
-        data.quiet_selected_index = ugui.listbox({
+        local listbox = {
             uid = listbox_uid,
-            rectangle = list_rect,
+            rectangle = ugui.internal.deep_clone(list_rect),
             items = items_to_show,
-            selected_index = data.quiet_selected_index,
+            selected_index = data.selected_index,
             plaintext = control.plaintext,
             z_index = math.maxinteger,
-        })
+        }
+        data.selected_index = ugui.listbox(listbox)
+        result.primary = data.selected_index
         ugui.internal.keyboard_captured_control = restore
 
-        if data.close_on_next_update then
+
+        local in_listbox = ugui.internal.is_point_inside_control(ugui.internal.environment.mouse_position, listbox)
+        local released_inside = ugui.internal.is_mouse_just_up() and in_listbox
+        local clicked_outside =
+            ugui.internal.is_mouse_just_down()
+            and not (
+                    in_listbox
+                    or ugui.internal.is_point_inside_control(ugui.internal.environment.mouse_position, control)
+                    )
+
+        if released_inside or clicked_outside then
             data.open = false
             data.search_text = nil
-            -- Commit the selection
-            data.selected_index = data.filtered_to_original and data.filtered_to_original[data.quiet_selected_index] or data.quiet_selected_index
-        end
+            result.meta.signal_change = ugui.signal_change_states.ended
 
-        data.close_on_next_update =
-            data.open
-            and ugui.internal.is_mouse_just_down()
-            and not ugui.internal.is_point_inside_control(ugui.internal.environment.mouse_position, control)
+            -- discard the intermediate result when the user did not confirm it
+            if clicked_outside or (data.filtered_items and next(data.filtered_items) == nil) then
+                data.selected_index = control.selected_index
+                result.primary = control.selected_index
+            end
+        end
+    else
+        data.selected_index = control.selected_index
     end
 
     return result.primary, result.meta

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -163,51 +163,49 @@ ugui.combobox = function(control)
             data.filtered_to_original = nil
         end
 
-        if data.open then
-            local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
+        local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
 
-            local width = control.rectangle.width
-            if control.rectangle.x + width > ugui.internal.environment.window_size.x then
-                width = ugui.internal.environment.window_size.x - control.rectangle.x
-            end
-
-            local height = content_bounds.height
-            if control.rectangle.y + height > ugui.internal.environment.window_size.y then
-                height = ugui.internal.environment.window_size.y - control.rectangle.y -
-                    ugui.standard_styler.params.listbox_item.height * 2
-            end
-
-            local list_rect = {
-                x = control.rectangle.x,
-                y = control.rectangle.y + control.rectangle.height,
-                width = width,
-                height = height,
-            }
-
-            local restore = ugui.internal.keyboard_captured_control
-            ugui.internal.keyboard_captured_control = listbox_uid
-            data.quiet_selected_index = ugui.listbox({
-                uid = listbox_uid,
-                rectangle = list_rect,
-                items = items_to_show,
-                selected_index = data.quiet_selected_index,
-                plaintext = control.plaintext,
-                z_index = math.maxinteger,
-            })
-            ugui.internal.keyboard_captured_control = restore
-
-            if data.close_on_next_update then
-                data.open = false
-                data.search_text = nil
-                -- Commit the selection
-                data.selected_index = data.filtered_to_original and data.filtered_to_original[data.quiet_selected_index] or data.quiet_selected_index
-            end
-
-            data.close_on_next_update =
-                data.open
-                and ugui.internal.is_mouse_just_down()
-                and not ugui.internal.is_point_inside_control(ugui.internal.environment.mouse_position, control)
+        local width = control.rectangle.width
+        if control.rectangle.x + width > ugui.internal.environment.window_size.x then
+            width = ugui.internal.environment.window_size.x - control.rectangle.x
         end
+
+        local height = content_bounds.height
+        if control.rectangle.y + height > ugui.internal.environment.window_size.y then
+            height = ugui.internal.environment.window_size.y - control.rectangle.y -
+                ugui.standard_styler.params.listbox_item.height * 2
+        end
+
+        local list_rect = {
+            x = control.rectangle.x,
+            y = control.rectangle.y + control.rectangle.height,
+            width = width,
+            height = height,
+        }
+
+        local restore = ugui.internal.keyboard_captured_control
+        ugui.internal.keyboard_captured_control = listbox_uid
+        data.quiet_selected_index = ugui.listbox({
+            uid = listbox_uid,
+            rectangle = list_rect,
+            items = items_to_show,
+            selected_index = data.quiet_selected_index,
+            plaintext = control.plaintext,
+            z_index = math.maxinteger,
+        })
+        ugui.internal.keyboard_captured_control = restore
+
+        if data.close_on_next_update then
+            data.open = false
+            data.search_text = nil
+            -- Commit the selection
+            data.selected_index = data.filtered_to_original and data.filtered_to_original[data.quiet_selected_index] or data.quiet_selected_index
+        end
+
+        data.close_on_next_update =
+            data.open
+            and ugui.internal.is_mouse_just_down()
+            and not ugui.internal.is_point_inside_control(ugui.internal.environment.mouse_position, control)
     end
 
     return result.primary, result.meta

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -7,6 +7,7 @@
 ---@field public items RichText[] The items contained in the control.
 ---@field public selected_index integer? The index of the currently selected item into the items array. If nil, no item is selected.
 ---@field public editable boolean? Whether the user can type in the combobox to filter the items.
+---@field public preview_change boolean? Whether the selection is returned while the combobox is open.
 ---A combobox which allows the user to choose from a list of items.
 
 ---@type ControlRegistryEntry
@@ -63,8 +64,10 @@ ugui.registry.combobox = {
 
 
 ---Places a ComboBox.
+---
+---When preview_change is set, meta.signal_change == ugui.signal_change_states.ended may be used to determine when the combobox was closed to confirm the new selection.
 ---@param control ComboBox The control table.
----@return integer, Meta # The new selected index.
+---@return integer selected_index, Meta meta The new selected index and metadata.
 ugui.combobox = function(control)
     local result = ugui.control(control, 'combobox')
     local data = ugui.internal.control_data[control.uid]
@@ -214,5 +217,6 @@ ugui.combobox = function(control)
         data.selected_index = control.selected_index
     end
 
-    return result.primary, result.meta
+    local yield_primary = (control.preview_change or result.meta.signal_change == ugui.signal_change_states.ended)
+    return yield_primary and result.primary or control.selected_index, result.meta
 end

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -37,17 +37,6 @@ ugui.registry.combobox = {
             data.open = not data.open
         end
 
-        if data.open then
-            -- allow confirming the selection with return when the control itself or the textbox captures keyboard input
-            if ugui.internal.keyboard_captured_control == control.uid + (control.editable and 1 or 0) then
-                for _, e in ipairs(ugui.internal.environment.key_events) do
-                    if e.keycode == ugui.keycodes.VK_RETURN and e.pressed then
-                        data.close_on_next_update = true
-                    end
-                end
-            end
-        end
-
         local selected_index = data.filtered_to_original and data.filtered_to_original[data.selected_index] or data.selected_index
 
         local signal_change = control.selected_index ~= selected_index
@@ -188,6 +177,18 @@ ugui.combobox = function(control)
         result.primary = data.selected_index
         ugui.internal.keyboard_captured_control = restore
 
+        local enter_pressed = false
+        -- allow confirming the selection with return when any of the owned controls captures keyboard input
+        if ugui.internal.keyboard_captured_control >= control.uid
+            and ugui.internal.keyboard_captured_control <= listbox_uid
+        then
+            for _, e in ipairs(ugui.internal.environment.key_events) do
+                if e.keycode == ugui.keycodes.VK_RETURN and e.pressed then
+                    enter_pressed = true
+                    break
+                end
+            end
+        end
 
         local in_listbox = ugui.internal.is_point_inside_control(ugui.internal.environment.mouse_position, listbox)
         local released_inside = ugui.internal.is_mouse_just_up() and in_listbox
@@ -198,7 +199,7 @@ ugui.combobox = function(control)
                     or ugui.internal.is_point_inside_control(ugui.internal.environment.mouse_position, control)
                     )
 
-        if released_inside or clicked_outside then
+        if enter_pressed or released_inside or clicked_outside then
             data.open = false
             data.search_text = nil
             result.meta.signal_change = ugui.signal_change_states.ended

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -185,7 +185,8 @@ ugui.combobox = function(control)
 
         local enter_pressed = false
         -- allow confirming the selection with return when any of the owned controls captures keyboard input
-        if ugui.internal.keyboard_captured_control >= control.uid
+        if ugui.internal.keyboard_captured_control ~= nil
+            and ugui.internal.keyboard_captured_control >= control.uid
             and ugui.internal.keyboard_captured_control <= highest_owned_uid
         then
             for _, e in ipairs(ugui.internal.environment.key_events) do
@@ -200,6 +201,7 @@ ugui.combobox = function(control)
         local released_inside = ugui.internal.is_mouse_just_up() and in_listbox
         local clicked_outside =
             ugui.internal.is_mouse_just_down()
+            and ugui.internal.hovered_control ~= nil
             and (ugui.internal.hovered_control < control.uid or ugui.internal.hovered_control > highest_owned_uid)
 
         if enter_pressed or released_inside or clicked_outside then

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -200,6 +200,11 @@ ugui.combobox = function(control)
             and not (
                     in_listbox
                     or ugui.internal.is_point_inside_control(ugui.internal.environment.mouse_position, control)
+                    or (-- weird hack to discover whether the user intends to scroll:
+                        -- this works because the listbox logic mutates its rectangle to be smaller if it spawns a scrollbar
+                        BreitbandGraphics.is_point_inside_rectangle(ugui.internal.environment.mouse_position, list_rect)
+                        and not in_listbox
+                        )
                     )
 
         if enter_pressed or released_inside or clicked_outside then

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -7,7 +7,7 @@
 ---@field public items RichText[] The items contained in the control.
 ---@field public selected_index integer? The index of the currently selected item into the items array. If nil, no item is selected.
 ---@field public editable boolean? Whether the user can type in the combobox to filter the items.
----@field public preview_change boolean? Whether the selection is returned while the combobox is open.
+---@field public preview_change boolean? Whether the returned selected index can change while the combobox is open.
 ---A combobox which allows the user to choose from a list of items.
 
 ---@type ControlRegistryEntry

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -65,7 +65,7 @@ ugui.registry.combobox = {
 
 ---Places a ComboBox.
 ---
----When preview_change is set, meta.signal_change == ugui.signal_change_states.ended may be used to determine when the combobox was closed to confirm the new selection.
+---When preview_change is set, `meta.signal_change == ugui.signal_change_states.ended` may be used to determine when the combobox was closed to confirm the new selection.
 ---@param control ComboBox The control table.
 ---@return integer selected_index, Meta meta The new selected index and metadata.
 ugui.combobox = function(control)


### PR DESCRIPTION
This changes the `signal_change` behavior of comboboxes as follows:
- While the listbox is open, the value is `ongoing` if the selected original index is different from `control.selected_index`, or `none` otherwise.
- When the listbox was just closed and the selected original index is different from `control.selected_index`, the value is `ended`
- The value is virtually never `started`. Should maybe be changed.

This enables users of the `ugui.combobox` API to react to the `ended` signal_change, fixing usability issues that would arise from prematurely updating the value fed into `control.selected_index`.

Additionally, the up and down arrow keys may be used to move the selected index, and enter may be used to confirm the selection (i.e. close the listbox).