### PR TITLE
feat!: tree scene hierarchy and single-pass layout system 

### DIFF
--- a/build.py
+++ b/build.py
@@ -38,6 +38,7 @@ JOBS: list[tuple[list[Path], Path]] = [
             Path("src/ugui/helpers.lua"),
             Path("src/ugui/styler.lua"),
             Path("src/ugui/controls/control.lua"),
+            Path("src/ugui/controls/panel.lua"),
             Path("src/ugui/controls/label.lua"),
             Path("src/ugui/controls/button.lua"),
             Path("src/ugui/controls/toggle_button.lua"),

--- a/demos/base.lua
+++ b/demos/base.lua
@@ -18,6 +18,7 @@ ugui.STATIC_ENV = {
     },
 }
 
+d2d.set_target_fps(24)
 local frame_times = {}
 local last_frame_time = nil
 local key_events = {}

--- a/demos/base.lua
+++ b/demos/base.lua
@@ -18,7 +18,6 @@ ugui.STATIC_ENV = {
     },
 }
 
-d2d.set_target_fps(24)
 local frame_times = {}
 local last_frame_time = nil
 local key_events = {}

--- a/demos/breitbandgraphics_draw_image2.lua
+++ b/demos/breitbandgraphics_draw_image2.lua
@@ -20,7 +20,7 @@ emu.atdrawd2d(function()
     do
         local x, y = COL1_X, ROW1_Y
         ugui.label({
-            uid = 1,
+            uid = 100,
             rectangle = {x = x, y = y, width = IMG_W, height = LABEL_H},
             text = '1. Natural size (destx2/y2 = nil)',
             color = BreitbandGraphics.colors.black,
@@ -37,7 +37,7 @@ emu.atdrawd2d(function()
     do
         local x, y = COL2_X, ROW1_Y
         ugui.label({
-            uid = 2,
+            uid = 200,
             rectangle = {x = x, y = y, width = IMG_W, height = LABEL_H},
             text = '2. Scaled to ' .. IMG_W .. 'x' .. IMG_H,
             color = BreitbandGraphics.colors.black,
@@ -54,7 +54,7 @@ emu.atdrawd2d(function()
     do
         local x, y = COL3_X, ROW1_Y
         ugui.label({
-            uid = 3,
+            uid = 300,
             rectangle = {x = x, y = y, width = IMG_W, height = LABEL_H},
             text = '3. Source crop (top-left quarter)',
             color = BreitbandGraphics.colors.black,
@@ -77,7 +77,7 @@ emu.atdrawd2d(function()
     do
         local x, y = COL1_X, ROW2_Y
         ugui.label({
-            uid = 4,
+            uid = 400,
             rectangle = {x = x, y = y, width = IMG_W, height = LABEL_H},
             text = '4. Red tint',
             color = BreitbandGraphics.colors.black,
@@ -95,7 +95,7 @@ emu.atdrawd2d(function()
     do
         local x, y = COL2_X, ROW2_Y
         ugui.label({
-            uid = 5,
+            uid = 500,
             rectangle = {x = x, y = y, width = IMG_W, height = LABEL_H},
             text = '5. Nearest-neighbor interp (0)',
             color = BreitbandGraphics.colors.black,
@@ -117,7 +117,7 @@ emu.atdrawd2d(function()
     do
         local x, y = COL3_X, ROW2_Y
         ugui.label({
-            uid = 6,
+            uid = 600,
             rectangle = {x = x, y = y, width = IMG_W, height = LABEL_H},
             text = '6. Linear interp (1)',
             color = BreitbandGraphics.colors.black,

--- a/demos/colorful_selection.lua
+++ b/demos/colorful_selection.lua
@@ -26,7 +26,7 @@ emu.atdrawd2d(function()
     ugui.standard_styler.params.numberbox.selection = selection_color
 
     text = ugui.textbox({
-        uid = 1,
+        uid = 100,
         rectangle = { x = 10, y = 10, width = 100, height = 20 },
         text = text,
     })

--- a/demos/control_gallery.lua
+++ b/demos/control_gallery.lua
@@ -5,7 +5,7 @@ emu.atdrawd2d(function()
     begin_frame()
 
     ugui.button({
-        uid = 0,
+        uid = 100,
         rectangle = {
             x = 0,
             y = 10,
@@ -16,7 +16,7 @@ emu.atdrawd2d(function()
     })
 
     if (ugui.button({
-            uid = 1,
+            uid = 200,
             is_enabled = false,
             rectangle = {
                 x = 100,
@@ -30,7 +30,7 @@ emu.atdrawd2d(function()
     end
 
     ugui.textbox({
-        uid = 2,
+        uid = 300,
         rectangle = {
             x = 0,
             y = 50,
@@ -41,7 +41,7 @@ emu.atdrawd2d(function()
     })
 
     ugui.textbox({
-        uid = 3,
+        uid = 400,
         is_enabled = false,
         rectangle = {
             x = 100,
@@ -53,7 +53,7 @@ emu.atdrawd2d(function()
     })
 
     ugui.combobox({
-        uid = 4,
+        uid = 500,
         rectangle = {
             x = 0,
             y = 90,
@@ -67,7 +67,7 @@ emu.atdrawd2d(function()
     })
 
     ugui.combobox({
-        uid = 5,
+        uid = 600,
         is_enabled = false,
         rectangle = {
             x = 100,
@@ -82,7 +82,7 @@ emu.atdrawd2d(function()
     })
 
     value = ugui.trackbar({
-        uid = 6,
+        uid = 700,
         rectangle = {
             x = 0,
             y = 130,
@@ -93,7 +93,7 @@ emu.atdrawd2d(function()
     })
 
     ugui.trackbar({
-        uid = 7,
+        uid = 800,
         is_enabled = false,
         rectangle = {
             x = 100,
@@ -106,7 +106,7 @@ emu.atdrawd2d(function()
 
 
     ugui.listbox({
-        uid = 8,
+        uid = 900,
         rectangle = {
             x = 0,
             y = 170,
@@ -121,7 +121,7 @@ emu.atdrawd2d(function()
     })
 
     ugui.listbox({
-        uid = 9,
+        uid = 1000,
         is_enabled = false,
         rectangle = {
             x = 100,
@@ -137,7 +137,7 @@ emu.atdrawd2d(function()
     })
 
     ugui.joystick({
-        uid = 10,
+        uid = 1100,
         rectangle = {
             x = 0,
             y = 210,
@@ -152,7 +152,7 @@ emu.atdrawd2d(function()
     })
 
     ugui.joystick({
-        uid = 11,
+        uid = 1200,
         is_enabled = false,
         rectangle = {
             x = 100,

--- a/demos/interaction_state.lua
+++ b/demos/interaction_state.lua
@@ -32,27 +32,27 @@ emu.atdrawd2d(function()
     begin_frame()
 
     ugui.listbox({
-        uid = 1,
+        uid = 100,
         rectangle = {x = 10, y = 40, width = 100, height = 200},
         items = interaction_logs,
         selected_index = nil,
     })
 
     local pressed, meta = ugui.button({
-        uid = 10,
+        uid = 200,
         rectangle = {x = 120, y = 10, width = 100, height = 23},
         text = 'Hello, world!',
     })
 
     checked, meta = ugui.toggle_button({
-        uid = 15,
+        uid = 300,
         rectangle = {x = 120, y = 35, width = 100, height = 23},
         text = 'Hello, world!',
         is_checked = checked,
     })
 
     index, meta = ugui.listbox({
-        uid = 20,
+        uid = 400,
         rectangle = {x = 230, y = 40, width = 100, height = 200},
         text = 'Hello, world!',
         items = items,

--- a/demos/internal_testing.lua
+++ b/demos/internal_testing.lua
@@ -115,7 +115,7 @@ emu.atdrawd2d(function()
     begin_frame()
 
     selected_index = ugui.combobox({
-        uid = 0,
+        uid = 100,
         rectangle = {
             x = 5,
             y = 5,
@@ -128,7 +128,7 @@ emu.atdrawd2d(function()
 
     if menu_open then
         local result = ugui.menu({
-            uid = 5,
+            uid = 200,
             rectangle = {
                 x = 50,
                 y = 76,
@@ -152,7 +152,7 @@ emu.atdrawd2d(function()
     end
 
     if ugui.button({
-            uid = 500,
+            uid = 300,
             rectangle = {
                 x = 5,
                 y = 55,
@@ -165,7 +165,7 @@ emu.atdrawd2d(function()
     end
 
     selected_index_2 = ugui.listbox({
-        uid = 1000,
+        uid = 400,
         is_enabled = true,
         rectangle = {
             x = 5,
@@ -179,7 +179,7 @@ emu.atdrawd2d(function()
     })
 
     ugui.listbox({
-        uid = 6000,
+        uid = 500,
         is_enabled = true,
         rectangle = {
             x = 300,
@@ -191,7 +191,7 @@ emu.atdrawd2d(function()
     })
 
     text = ugui.textbox({
-        uid = 1500,
+        uid = 600,
         rectangle = {
             x = 5,
             y = 30,
@@ -202,7 +202,7 @@ emu.atdrawd2d(function()
     })
 
     if ugui.button({
-            uid = 2000,
+            uid = 700,
             rectangle = {
                 x = initial_size.width - 90,
                 y = initial_size.height - 90,
@@ -215,7 +215,7 @@ emu.atdrawd2d(function()
     end
 
     selected_index = ugui.combobox({
-        uid = 2500,
+        uid = 800,
         rectangle = {
             x = 720,
             y = 10,
@@ -227,7 +227,7 @@ emu.atdrawd2d(function()
     })
 
     ugui.combobox({
-        uid = 3000,
+        uid = 900,
         rectangle = {
             x = initial_size.width - 90,
             y = initial_size.height - 250,
@@ -239,7 +239,7 @@ emu.atdrawd2d(function()
     })
 
     ugui.combobox({
-        uid = 3500,
+        uid = 1000,
         rectangle = {
             x = 300,
             y = 10,

--- a/demos/layout.lua
+++ b/demos/layout.lua
@@ -74,6 +74,32 @@ local pages = {
             selected_index = _sl,
         })
     end,
+    function()
+        _sl = _sl or 1
+        _sl = ugui.listbox({
+            uid = 120,
+            align = 'center',
+            size = '130px 130px',
+            horizontal_scroll = true,
+            items = {
+                'Item Item Item Item Item Item Item Item Item 1',
+                'Item Item Item Item Item Item Item Item Item 2',
+                'Item Item Item Item Item Item Item Item Item 3',
+                'Item Item Item Item Item Item Item Item Item 4',
+                'Item Item Item Item Item Item Item Item Item 5',
+                'Item Item Item Item Item Item Item Item Item 6',
+                'Item Item Item Item Item Item Item Item Item 7',
+                'Item Item Item Item Item Item Item Item Item 8',
+                'Item Item Item Item Item Item Item Item Item 9',
+                'Item Item Item Item Item Item Item Item Item 10000000',
+                'Item Item Item Item Item Item Item Item Item 10000000',
+                'Item Item Item Item Item Item Item Item Item 10000000',
+                'Item Item Item Item Item Item Item Item Item 10000000',
+                'Item Item Item Item Item Item Item Item Item 10000000',
+            },
+            selected_index = _sl,
+        })
+    end,
 }
 
 local page = 1

--- a/demos/layout.lua
+++ b/demos/layout.lua
@@ -3,62 +3,100 @@ dofile(path_root .. 'base.lua')
 
 ugui.DEBUG = true
 
+local pages = {
+    function()
+        ugui.button({
+            uid = 10,
+            text = '',
+            size = '30% 30%',
+            align = 'center',
+            padding = '20px',
+        }, function()
+            ugui.button({
+                uid = 20,
+                text = 'top left',
+            })
+            ugui.button({
+                uid = 30,
+                text = 'top center',
+                align = 'center top',
+            })
+            ugui.button({
+                uid = 40,
+                text = 'top right',
+                align = 'right top',
+            })
+            ugui.button({
+                uid = 50,
+                text = 'center left',
+                align = 'left center',
+            })
+            ugui.button({
+                uid = 60,
+                text = 'center center',
+                align = 'center',
+                padding = '20px',
+            })
+            ugui.button({
+                uid = 70,
+                text = 'center right',
+                align = 'right center',
+            })
+            ugui.button({
+                uid = 80,
+                text = 'bottom left',
+                align = 'left bottom',
+            })
+            ugui.button({
+                uid = 90,
+                text = 'bottom center',
+                align = 'center bottom',
+            })
+            ugui.button({
+                uid = 100,
+                text = 'bottom right',
+                align = 'right bottom',
+            })
+        end)
+    end,
+    function()
+        ugui.listbox({
+            uid = 10,
+            items = {
+                'Item 1',
+                'Item 2',
+                'Item 3',
+                'Item 4',
+                'Item 5',
+            },
+        })
+    end,
+}
+
+local page = 1
+
 emu.atdrawd2d(function()
     begin_frame()
 
-    ugui.button({
-        uid = 10,
-        text = '',
-        size = '30% 30%',
-        align = 'center',
-        padding = '20px'
-    }, function()
-        ugui.button({
-            uid = 20,
-            text = 'top left',
-        })
-        ugui.button({
-            uid = 30,
-            text = 'top center',
-            align = 'center top',
-        })
-        ugui.button({
-            uid = 40,
-            text = 'top right',
-            align = 'right top',
-        })
-        ugui.button({
-            uid = 50,
-            text = 'center left',
-            align = 'left center',
-        })
-        ugui.button({
-            uid = 60,
-            text = 'center center',
-            align = 'center',
-            padding = '20px'
-        })
-        ugui.button({
-            uid = 70,
-            text = 'center right',
-            align = 'right center',
-        })
-        ugui.button({
-            uid = 80,
-            text = 'bottom left',
-            align = 'left bottom',
-        })
-        ugui.button({
-            uid = 90,
-            text = 'bottom center',
-            align = 'center bottom',
-        })
-        ugui.button({
-            uid = 100,
-            text = 'bottom right',
-            align = 'right bottom',
-        })
-    end)
+    ugui.label({
+        uid = 2,
+        size = '100% auto',
+        font_size = 24,
+        text = string.format('Press left/right arrows to switch pages (%d/%d)', page, #pages),
+        color = {r = 0, g = 0, b = 0},
+    })
+
+    pages[page]()
+
+    for _, e in ipairs(ugui.internal.environment.key_events) do
+        if e.pressed and e.keycode == ugui.keycodes.VK_LEFT then
+            page = page - 1
+            if page < 1 then page = #pages end
+        elseif e.pressed and e.keycode == ugui.keycodes.VK_RIGHT then
+            page = page + 1
+            if page > #pages then page = 1 end
+        end
+    end
 
     end_frame()
 end)

--- a/demos/layout.lua
+++ b/demos/layout.lua
@@ -60,8 +60,10 @@ local pages = {
         end)
     end,
     function()
-        ugui.listbox({
-            uid = 10,
+        _sl = 1
+        _sl = ugui.listbox({
+            uid = 110,
+            align = 'center',
             items = {
                 'Item 1',
                 'Item 2',
@@ -69,6 +71,7 @@ local pages = {
                 'Item 4',
                 'Item 5',
             },
+            selected_index = _sl,
         })
     end,
 }

--- a/demos/layout.lua
+++ b/demos/layout.lua
@@ -6,54 +6,54 @@ ugui.DEBUG = true
 local pages = {
     function()
         ugui.button({
-            uid = 10,
+            uid = 100,
             text = '',
             size = '0.3 0.3',
             align = 'center',
             padding = '20px',
         }, function()
             ugui.button({
-                uid = 20,
+                uid = 200,
                 text = 'top left',
             })
             ugui.button({
-                uid = 30,
+                uid = 300,
                 text = 'top center',
                 align = 'center top',
             })
             ugui.button({
-                uid = 40,
+                uid = 400,
                 text = 'top right',
                 align = 'right top',
             })
             ugui.button({
-                uid = 50,
+                uid = 500,
                 text = 'center left',
                 align = 'left center',
             })
             ugui.button({
-                uid = 60,
+                uid = 600,
                 text = 'center center',
                 align = 'center',
                 padding = '20px',
             })
             ugui.button({
-                uid = 70,
+                uid = 700,
                 text = 'center right',
                 align = 'right center',
             })
             ugui.button({
-                uid = 80,
+                uid = 800,
                 text = 'bottom left',
                 align = 'left bottom',
             })
             ugui.button({
-                uid = 90,
+                uid = 900,
                 text = 'bottom center',
                 align = 'center bottom',
             })
             ugui.button({
-                uid = 100,
+                uid = 1000,
                 text = 'bottom right',
                 align = 'right bottom',
             })
@@ -62,7 +62,7 @@ local pages = {
     function()
         _sl = _sl or 1
         _sl = ugui.listbox({
-            uid = 110,
+            uid = 1100,
             align = 'center',
             items = {
                 'Item 1',
@@ -77,7 +77,7 @@ local pages = {
     function()
         _sl2 = _sl2 or 1
         _sl2 = ugui.listbox({
-            uid = 120,
+            uid = 1200,
             align = 'center',
             size = '130px 130px',
             horizontal_scroll = true,
@@ -103,7 +103,7 @@ local pages = {
     function()
         _sl3 = _sl3 or 1
         _sl3 = ugui.combobox({
-            uid = 130,
+            uid = 1300,
             align = 'center',
             padding = '40px 10px',
             items = {
@@ -124,7 +124,7 @@ emu.atdrawd2d(function()
     begin_frame()
 
     ugui.label({
-        uid = 2,
+        uid = 1400,
         size = '1 auto',
         font_size = 24,
         text = string.format('Press left/right arrows to switch pages (%d/%d)', page, #pages),

--- a/demos/layout.lua
+++ b/demos/layout.lua
@@ -75,8 +75,8 @@ local pages = {
         })
     end,
     function()
-        _sl = _sl or 1
-        _sl = ugui.listbox({
+        _sl2 = _sl2 or 1
+        _sl2 = ugui.listbox({
             uid = 120,
             align = 'center',
             size = '130px 130px',
@@ -97,7 +97,23 @@ local pages = {
                 'Item Item Item Item Item Item Item Item Item 10000000',
                 'Item Item Item Item Item Item Item Item Item 10000000',
             },
-            selected_index = _sl,
+            selected_index = _sl2,
+        })
+    end,
+    function()
+        _sl3 = _sl3 or 1
+        _sl3 = ugui.combobox({
+            uid = 130,
+            align = 'center',
+            padding = '40px 10px',
+            items = {
+                'Item 1',
+                'Item 2',
+                'Item 3',
+                'Item 4',
+                'Item 5',
+            },
+            selected_index = _sl3,
         })
     end,
 }

--- a/demos/layout.lua
+++ b/demos/layout.lua
@@ -1,0 +1,68 @@
+local path_root = debug.getinfo(1).source:sub(2):gsub('\\[^\\]+\\[^\\]+$', '\\') .. 'demos\\'
+dofile(path_root .. 'base.lua')
+
+ugui.DEBUG = true
+
+emu.atdrawd2d(function()
+    begin_frame()
+
+    ugui.button({
+        uid = 10,
+        text = '',
+        size = '30% 30%',
+        x_align = 0.5,
+        y_align = 0.5,
+    }, function()
+        ugui.button({
+            uid = 20,
+            text = 'top left',
+        })
+        ugui.button({
+            uid = 30,
+            text = 'top center',
+            x_align = 0.5,
+        })
+        ugui.button({
+            uid = 40,
+            text = 'top right',
+            x_align = 1,
+        })
+        ugui.button({
+            uid = 50,
+            text = 'center left',
+            y_align = 0.5,
+        })
+        ugui.button({
+            uid = 60,
+            text = 'center center',
+            x_align = 0.5,
+            y_align = 0.5,
+        })
+        ugui.button({
+            uid = 70,
+            text = 'center right',
+            x_align = 1,
+            y_align = 0.5,
+        })
+        ugui.button({
+            uid = 80,
+            text = 'bottom left',
+            x_align = 0,
+            y_align = 1,
+        })
+        ugui.button({
+            uid = 90,
+            text = 'bottom center',
+            x_align = 0.5,
+            y_align = 1,
+        })
+        ugui.button({
+            uid = 100,
+            text = 'bottom right',
+            x_align = 1,
+            y_align = 1,
+        })
+    end)
+
+    end_frame()
+end)

--- a/demos/layout.lua
+++ b/demos/layout.lua
@@ -10,8 +10,7 @@ emu.atdrawd2d(function()
         uid = 10,
         text = '',
         size = '30% 30%',
-        x_align = 0.5,
-        y_align = 0.5,
+        align = 'center',
     }, function()
         ugui.button({
             uid = 20,
@@ -20,47 +19,42 @@ emu.atdrawd2d(function()
         ugui.button({
             uid = 30,
             text = 'top center',
-            x_align = 0.5,
+            align = 'center top',
         })
         ugui.button({
             uid = 40,
             text = 'top right',
-            x_align = 1,
+            align = 'right top',
         })
         ugui.button({
             uid = 50,
             text = 'center left',
-            y_align = 0.5,
+            align = 'left center',
         })
         ugui.button({
             uid = 60,
             text = 'center center',
-            x_align = 0.5,
-            y_align = 0.5,
+            align = 'center',
         })
         ugui.button({
             uid = 70,
             text = 'center right',
-            x_align = 1,
-            y_align = 0.5,
+            align = 'right center',
         })
         ugui.button({
             uid = 80,
             text = 'bottom left',
-            x_align = 0,
-            y_align = 1,
+            align = 'left bottom',
         })
         ugui.button({
             uid = 90,
             text = 'bottom center',
-            x_align = 0.5,
-            y_align = 1,
+            align = 'center bottom',
         })
         ugui.button({
             uid = 100,
             text = 'bottom right',
-            x_align = 1,
-            y_align = 1,
+            align = 'right bottom',
         })
     end)
 

--- a/demos/layout.lua
+++ b/demos/layout.lua
@@ -9,7 +9,7 @@ local pages = {
             uid = 100,
             text = '',
             size = '0.3 0.3',
-            align = 'center',
+            align = '0.5',
             padding = '20px',
         }, function()
             ugui.button({
@@ -19,43 +19,43 @@ local pages = {
             ugui.button({
                 uid = 300,
                 text = 'top center',
-                align = 'center top',
+                align = '0.5 0',
             })
             ugui.button({
                 uid = 400,
                 text = 'top right',
-                align = 'right top',
+                align = '1 0',
             })
             ugui.button({
                 uid = 500,
                 text = 'center left',
-                align = 'left center',
+                align = '0 0.5',
             })
             ugui.button({
                 uid = 600,
                 text = 'center center',
-                align = 'center',
+                align = '0.5',
                 padding = '20px',
             })
             ugui.button({
                 uid = 700,
                 text = 'center right',
-                align = 'right center',
+                align = '1 0.5',
             })
             ugui.button({
                 uid = 800,
                 text = 'bottom left',
-                align = 'left bottom',
+                align = '0 1',
             })
             ugui.button({
                 uid = 900,
                 text = 'bottom center',
-                align = 'center bottom',
+                align = '0.5 1',
             })
             ugui.button({
                 uid = 1000,
                 text = 'bottom right',
-                align = 'right bottom',
+                align = '1 1',
             })
         end)
     end,
@@ -63,7 +63,7 @@ local pages = {
         _sl = _sl or 1
         _sl = ugui.listbox({
             uid = 1100,
-            align = 'center',
+            align = '0.5',
             items = {
                 'Item 1',
                 'Item 2',
@@ -78,7 +78,7 @@ local pages = {
         _sl2 = _sl2 or 1
         _sl2 = ugui.listbox({
             uid = 1200,
-            align = 'center',
+            align = '0.5',
             size = '130px 130px',
             horizontal_scroll = true,
             items = {
@@ -104,7 +104,7 @@ local pages = {
         _sl3 = _sl3 or 1
         _sl3 = ugui.combobox({
             uid = 1300,
-            align = 'center',
+            align = '0.5',
             padding = '40px 10px',
             items = {
                 'Item 1',

--- a/demos/layout.lua
+++ b/demos/layout.lua
@@ -60,7 +60,7 @@ local pages = {
         end)
     end,
     function()
-        _sl = 1
+        _sl = _sl or 1
         _sl = ugui.listbox({
             uid = 110,
             align = 'center',

--- a/demos/layout.lua
+++ b/demos/layout.lua
@@ -11,6 +11,7 @@ emu.atdrawd2d(function()
         text = '',
         size = '30% 30%',
         align = 'center',
+        padding = '20px'
     }, function()
         ugui.button({
             uid = 20,
@@ -35,6 +36,7 @@ emu.atdrawd2d(function()
             uid = 60,
             text = 'center center',
             align = 'center',
+            padding = '20px'
         })
         ugui.button({
             uid = 70,

--- a/demos/layout.lua
+++ b/demos/layout.lua
@@ -8,7 +8,7 @@ local pages = {
         ugui.button({
             uid = 10,
             text = '',
-            size = '30% 30%',
+            size = '0.3 0.3',
             align = 'center',
             padding = '20px',
         }, function()
@@ -125,7 +125,7 @@ emu.atdrawd2d(function()
 
     ugui.label({
         uid = 2,
-        size = '100% auto',
+        size = '1 auto',
         font_size = 24,
         text = string.format('Press left/right arrows to switch pages (%d/%d)', page, #pages),
         color = {r = 0, g = 0, b = 0},

--- a/demos/navigation.lua
+++ b/demos/navigation.lua
@@ -7,7 +7,7 @@ local is_joystick_enabled = true
 
 pages[1] = function()
     ugui.button({
-        uid = 0,
+        uid = 100,
 
         rectangle = {
             x = 5,
@@ -21,7 +21,7 @@ end
 
 pages[2] = function()
     ugui.joystick({
-        uid = 1,
+        uid = 200,
         is_enabled = is_joystick_enabled,
         rectangle = {
             x = 5,
@@ -37,7 +37,7 @@ pages[2] = function()
     })
 
     is_joystick_enabled = ugui.toggle_button({
-        uid = 2,
+        uid = 300,
 
         rectangle = {
             x = 5,
@@ -60,7 +60,7 @@ emu.atdrawd2d(function()
     end
 
     selected_page_index = ugui.combobox({
-        uid = 6000,
+        uid = 400,
 
         rectangle = {
             x = 5,
@@ -73,7 +73,7 @@ emu.atdrawd2d(function()
     })
 
     selected_page_index = ugui.carrousel_button({
-        uid = 60001,
+        uid = 500,
 
         rectangle = {
             x = 5,

--- a/demos/overlapping_controls.lua
+++ b/demos/overlapping_controls.lua
@@ -181,5 +181,77 @@ emu.atdrawd2d(function()
         items = {'a'},
         selected_index = nil,
     })
+    if ugui.button({
+            uid = 210,
+            rectangle = {x = 620, y = 10, width = 200, height = 200},
+            text = '',
+        }, function()
+            ugui.button({
+                uid = 220,
+                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                text = 'top left',
+            })
+            ugui.button({
+                uid = 230,
+                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                text = 'top center',
+                x_align = 0.5,
+            })
+            ugui.button({
+                uid = 240,
+                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                text = 'top right',
+                x_align = 1,
+            })
+            ugui.button({
+                uid = 250,
+                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                text = 'bottom left',
+                y_align = 1,
+            })
+            ugui.button({
+                uid = 260,
+                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                text = 'bottom center',
+                x_align = 0.5,
+                y_align = 1,
+            })
+            ugui.button({
+                uid = 270,
+                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                text = 'bottom right',
+                x_align = 1,
+                y_align = 1,
+            })
+            ugui.button({
+                uid = 280,
+                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                text = 'left center',
+                y_align = 0.5,
+            })
+            ugui.button({
+                uid = 290,
+                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                text = 'right center',
+                x_align = 1,
+                y_align = 0.5,
+            })
+            ugui.button({
+                uid = 300,
+                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                text = 'center',
+                x_align = 0.5,
+                y_align = 0.5,
+            })
+            ugui.button({
+                uid = 310,
+                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                text = 'smooth',
+                x_align = (math.sin(os.clock() * 2) + 1) / 2,
+                y_align = (math.cos(os.clock() * 2) + 1) / 2,
+            })
+        end) then
+        index = index + 1
+    end
     end_frame()
 end)

--- a/demos/overlapping_controls.lua
+++ b/demos/overlapping_controls.lua
@@ -195,60 +195,55 @@ emu.atdrawd2d(function()
                 uid = 230,
                 rectangle = {x = 0, y = 0, width = 50, height = 23},
                 text = 'top center',
-                x_align = 0.5,
+                align = 'center top',
             })
             ugui.button({
                 uid = 240,
                 rectangle = {x = 0, y = 0, width = 50, height = 23},
                 text = 'top right',
-                x_align = 1,
+                align = 'right top',
             })
             ugui.button({
                 uid = 250,
                 rectangle = {x = 0, y = 0, width = 50, height = 23},
                 text = 'bottom left',
-                y_align = 1,
+                align = 'left bottom',
             })
             ugui.button({
                 uid = 260,
                 rectangle = {x = 0, y = 0, width = 50, height = 23},
                 text = 'bottom center',
-                x_align = 0.5,
-                y_align = 1,
+                align = 'center bottom',
             })
             ugui.button({
                 uid = 270,
                 rectangle = {x = 0, y = 0, width = 50, height = 23},
                 text = 'bottom right',
-                x_align = 1,
-                y_align = 1,
+                align = 'right bottom',
             })
             ugui.button({
                 uid = 280,
                 rectangle = {x = 0, y = 0, width = 50, height = 23},
                 text = 'left center',
-                y_align = 0.5,
+                align = 'left center',
             })
             ugui.button({
                 uid = 290,
                 rectangle = {x = 0, y = 0, width = 50, height = 23},
                 text = 'right center',
-                x_align = 1,
-                y_align = 0.5,
+                align = 'right center',
             })
             ugui.button({
                 uid = 300,
                 rectangle = {x = 0, y = 0, width = 50, height = 23},
                 text = 'center',
-                x_align = 0.5,
-                y_align = 0.5,
+                align = 'center',
             })
             ugui.button({
                 uid = 310,
                 rectangle = {x = 0, y = 0, width = 50, height = 23},
                 text = 'smooth',
-                x_align = (math.sin(os.clock() * 2) + 1) / 2,
-                y_align = (math.cos(os.clock() * 2) + 1) / 2,
+                align = (math.sin(os.clock() * 2) + 1) / 2 .. ' ' .. (math.cos(os.clock() * 2) + 1) / 2,
             })
         end) then
         index = index + 1
@@ -269,8 +264,7 @@ emu.atdrawd2d(function()
                 uid = 340,
                 text = 'half\nheight',
                 size = '23px 50%',
-                x_align = 0.5,
-                y_align = 1,
+                align = '50% 100%',
             })
         end) then
         index = index + 1

--- a/demos/overlapping_controls.lua
+++ b/demos/overlapping_controls.lua
@@ -258,6 +258,7 @@ emu.atdrawd2d(function()
             margin = '650px 220px',
             size = '200px',
             text = '',
+            is_enabled = false
         }, function()
             ugui.button({
                 uid = 330,

--- a/demos/overlapping_controls.lua
+++ b/demos/overlapping_controls.lua
@@ -290,12 +290,12 @@ emu.atdrawd2d(function()
             ugui.button({
                 uid = 330,
                 text = 'half width',
-                size = '50% 23px',
+                size = '0.5 23px',
             })
             ugui.button({
                 uid = 340,
                 text = 'half\nheight',
-                size = '23px 50%',
+                size = '23px 0.5',
                 align = '50% 100%',
             })
         end) then

--- a/demos/overlapping_controls.lua
+++ b/demos/overlapping_controls.lua
@@ -253,5 +253,15 @@ emu.atdrawd2d(function()
         end) then
         index = index + 1
     end
+    if ugui.button({
+            uid = 320,
+            margin = '650px 220px',
+            size = '200px',
+            text = '',
+        }, function()
+
+        end) then
+        index = index + 1
+    end
     end_frame()
 end)

--- a/demos/overlapping_controls.lua
+++ b/demos/overlapping_controls.lua
@@ -219,56 +219,56 @@ emu.atdrawd2d(function()
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'top center',
-                align = 'center top',
+                align = '0.5 0',
             })
             ugui.button({
                 uid = 2500,
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'top right',
-                align = 'right top',
+                align = '1 0',
             })
             ugui.button({
                 uid = 2600,
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'bottom left',
-                align = 'left bottom',
+                align = '0 1',
             })
             ugui.button({
                 uid = 2700,
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'bottom center',
-                align = 'center bottom',
+                align = '0.5 1',
             })
             ugui.button({
                 uid = 2800,
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'bottom right',
-                align = 'right bottom',
+                align = '1 1',
             })
             ugui.button({
                 uid = 2900,
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'left center',
-                align = 'left center',
+                align = '0 0.5',
             })
             ugui.button({
                 uid = 3000,
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'right center',
-                align = 'right center',
+                align = '1 0.5',
             })
             ugui.button({
                 uid = 3100,
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'center',
-                align = 'center',
+                align = '0.5',
             })
             ugui.button({
                 uid = 3200,
@@ -296,7 +296,7 @@ emu.atdrawd2d(function()
                 uid = 3500,
                 text = 'half\nheight',
                 size = '23px 0.5',
-                align = '50% 100%',
+                align = '0.5 1',
             })
         end) then
         index = index + 1

--- a/demos/overlapping_controls.lua
+++ b/demos/overlapping_controls.lua
@@ -21,19 +21,22 @@ emu.atdrawd2d(function()
 
     if ugui.button({
             uid = 5,
-            rectangle = {x = 10, y = 10, width = 600, height = 400},
+            margin = '10px 10px',
+            size = '600px 400px',
             text = 'Hello, world!',
         }) then
         print('1')
     end
     if ugui.button({
             uid = 15,
-            rectangle = {x = 80 + math.sin(os.clock() * 5) * 10, y = 80 + math.cos(os.clock() * 5) * 10, width = 100, height = 50},
+            margin = (80 + math.sin(os.clock() * 5) * 10) .. 'px ' .. (80 + math.cos(os.clock() * 5) * 10) .. 'px',
+            size = '100px 50px',
             text = tostring(index),
         }, function()
             ugui.button({
                 uid = 999999,
-                rectangle = {x = 10, y = 10, width = 20, height = 20},
+                margin = '10px 10px',
+                size = '20px 20px',
                 text = '😀',
             })
         end) then
@@ -41,7 +44,8 @@ emu.atdrawd2d(function()
     end
     if ugui.button({
             uid = 25,
-            rectangle = {x = 80, y = 140, width = 100, height = 30},
+            margin = '80px 140px',
+            size = '100px 30px',
             text = 'Hello, world!',
             is_enabled = false,
         }) then
@@ -49,48 +53,56 @@ emu.atdrawd2d(function()
     end
     checked = ugui.toggle_button({
         uid = 35,
-        rectangle = {x = 80, y = 200, width = 200, height = 50},
+        margin = '80px 200px',
+        size = '200px 50px',
         text = 'Hello, world!',
         is_checked = checked,
     })
     text = ugui.textbox({
         uid = 45,
-        rectangle = {x = 20, y = 20, width = 100, height = 20},
+        margin = '20px 20px',
+        size = '100px 20px',
         text = text,
     })
     position = ugui.joystick({
         uid = 55,
-        rectangle = {x = 20, y = 200, width = 150, height = 150},
+        margin = '20px 200px',
+        size = '150px 150px',
         position = position,
     })
 
     index = ugui.listbox({
         uid = 65,
-        rectangle = {x = 20, y = 300, width = 120, height = 200},
+        margin = '20px 300px',
+        size = '120px 200px',
         items = items,
         selected_index = index,
     })
     value = ugui.scrollbar({
         uid = 75,
-        rectangle = {x = 230, y = 10, width = 20, height = 300},
+        margin = '230px 10px',
+        size = '20px 300px',
         value = value,
         ratio = 0.2,
     })
     value = ugui.scrollbar({
         uid = 85,
-        rectangle = {x = 280, y = 10, width = 300, height = 20},
+        margin = '280px 10px',
+        size = '300px 20px',
         value = value,
         ratio = 0.2,
     })
     index = ugui.combobox({
         uid = 95,
-        rectangle = {x = 200, y = 300, width = 160, height = 23},
+        margin = '200px 300px',
+        size = '160px 23px',
         items = items,
         selected_index = index,
     })
     ugui.joystick({
         uid = 105,
-        rectangle = {x = 200, y = 350, width = 150, height = 150},
+        margin = '200px 350px',
+        size = '150px 150px',
         position = {
             x = math.sin(os.clock() / 2) * 50,
             y = math.cos(os.clock() / 2) * 50,
@@ -103,7 +115,8 @@ emu.atdrawd2d(function()
     })
     ugui.joystick({
         uid = 115,
-        rectangle = {x = 355, y = 350, width = 150, height = 150},
+        margin = '355px 350px',
+        size = '150px 150px',
         position = {
             x = math.sin(os.clock() / 2) * 50,
             y = math.cos(os.clock() / 2) * 50,
@@ -111,19 +124,22 @@ emu.atdrawd2d(function()
     })
     index = ugui.carrousel_button({
         uid = 125,
-        rectangle = {x = 380, y = 300, width = 160, height = 23},
+        margin = '380px 300px',
+        size = '160px 23px',
         items = items,
         selected_index = index,
     })
 
     num = ugui.numberbox({
         uid = 135,
-        rectangle = {x = 350, y = 50, width = 160, height = 23},
+        margin = '350px 50px',
+        size = '160px 23px',
         value = num,
         places = 4,
     })
     BreitbandGraphics.draw_text2({
-        rectangle = {x = 515, y = 50, width = 999, height = 23},
+        margin = '515px 50px',
+        size = '999px 23px',
         align_x = BreitbandGraphics.alignment.start,
         text = tostring(num),
         color = BreitbandGraphics.colors.black,
@@ -132,13 +148,15 @@ emu.atdrawd2d(function()
     })
     num2 = ugui.numberbox({
         uid = 145,
-        rectangle = {x = 350, y = 75, width = 160, height = 23},
+        margin = '350px 75px',
+        size = '160px 23px',
         value = num2,
         places = 4,
         show_negative = true,
     })
     BreitbandGraphics.draw_text2({
-        rectangle = {x = 515, y = 75, width = 999, height = 23},
+        margin = '515px 75px',
+        size = '999px 23px',
         align_x = BreitbandGraphics.alignment.start,
         text = tostring(num2),
         color = BreitbandGraphics.colors.black,
@@ -147,7 +165,8 @@ emu.atdrawd2d(function()
     })
     ugui.label({
         uid = 155,
-        rectangle = {x = 350, y = 150, width = 160, height = 23},
+        margin = '350px 150px',
+        size = '160px 23px',
         text = 'Hello World!',
         color = BreitbandGraphics.colors.black,
         font_name = 'Wingdings',
@@ -155,7 +174,8 @@ emu.atdrawd2d(function()
     })
     ugui.label({
         uid = 165,
-        rectangle = {x = 350, y = 180, width = 160, height = 23},
+        margin = '350px 180px',
+        size = '160px 23px',
         text = 'Hello World!',
         color = BreitbandGraphics.colors.black,
         font_name = 'Consolas',
@@ -164,84 +184,98 @@ emu.atdrawd2d(function()
     })
     index = ugui.combobox({
         uid = 175,
-        rectangle = {x = 350, y = 230, width = 160, height = 23},
+        margin = '350px 230px',
+        size = '160px 23px',
         items = items,
         selected_index = index,
         editable = true,
     })
     ugui.listbox({
         uid = 185,
-        rectangle = {x = 560, y = 230, width = 160, height = 160},
+        margin = '560px 230px',
+        size = '160px 160px',
         items = {},
         selected_index = 1,
     })
     ugui.listbox({
         uid = 195,
-        rectangle = {x = 560, y = 360, width = 160, height = 160},
+        margin = '560px 360px',
+        size = '160px 160px',
         items = {'a'},
         selected_index = nil,
     })
     if ugui.button({
             uid = 210,
-            rectangle = {x = 620, y = 10, width = 200, height = 200},
+            margin = '620px 10px',
+            size = '200px 200px',
             text = '',
         }, function()
             ugui.button({
                 uid = 220,
-                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                margin = '0px 0px',
+                size = '50px 23px',
                 text = 'top left',
             })
             ugui.button({
                 uid = 230,
-                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                margin = '0px 0px',
+                size = '50px 23px',
                 text = 'top center',
                 align = 'center top',
             })
             ugui.button({
                 uid = 240,
-                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                margin = '0px 0px',
+                size = '50px 23px',
                 text = 'top right',
                 align = 'right top',
             })
             ugui.button({
                 uid = 250,
-                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                margin = '0px 0px',
+                size = '50px 23px',
                 text = 'bottom left',
                 align = 'left bottom',
             })
             ugui.button({
                 uid = 260,
-                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                margin = '0px 0px',
+                size = '50px 23px',
                 text = 'bottom center',
                 align = 'center bottom',
             })
             ugui.button({
                 uid = 270,
-                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                margin = '0px 0px',
+                size = '50px 23px',
                 text = 'bottom right',
                 align = 'right bottom',
             })
             ugui.button({
                 uid = 280,
-                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                margin = '0px 0px',
+                size = '50px 23px',
                 text = 'left center',
                 align = 'left center',
             })
             ugui.button({
                 uid = 290,
-                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                margin = '0px 0px',
+                size = '50px 23px',
                 text = 'right center',
                 align = 'right center',
             })
             ugui.button({
                 uid = 300,
-                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                margin = '0px 0px',
+                size = '50px 23px',
                 text = 'center',
                 align = 'center',
             })
             ugui.button({
                 uid = 310,
-                rectangle = {x = 0, y = 0, width = 50, height = 23},
+                margin = '0px 0px',
+                size = '50px 23px',
                 text = 'smooth',
                 align = (math.sin(os.clock() * 2) + 1) / 2 .. ' ' .. (math.cos(os.clock() * 2) + 1) / 2,
             })

--- a/demos/overlapping_controls.lua
+++ b/demos/overlapping_controls.lua
@@ -20,7 +20,7 @@ emu.atdrawd2d(function()
     begin_frame()
 
     if ugui.button({
-            uid = 5,
+            uid = 100,
             margin = '10px 10px',
             size = '600px 400px',
             text = 'Hello, world!',
@@ -28,13 +28,13 @@ emu.atdrawd2d(function()
         print('1')
     end
     if ugui.button({
-            uid = 15,
+            uid = 200,
             margin = (80 + math.sin(os.clock() * 5) * 10) .. 'px ' .. (80 + math.cos(os.clock() * 5) * 10) .. 'px',
             size = '100px 50px',
             text = tostring(index),
         }, function()
             ugui.button({
-                uid = 999999,
+                uid = 300,
                 margin = '10px 10px',
                 size = '20px 20px',
                 text = '😀',
@@ -43,7 +43,7 @@ emu.atdrawd2d(function()
         index = index + 1
     end
     if ugui.button({
-            uid = 25,
+            uid = 400,
             margin = '80px 140px',
             size = '100px 30px',
             text = 'Hello, world!',
@@ -52,55 +52,55 @@ emu.atdrawd2d(function()
         print('3')
     end
     checked = ugui.toggle_button({
-        uid = 35,
+        uid = 500,
         margin = '80px 200px',
         size = '200px 50px',
         text = 'Hello, world!',
         is_checked = checked,
     })
     text = ugui.textbox({
-        uid = 45,
+        uid = 600,
         margin = '20px 20px',
         size = '100px 20px',
         text = text,
     })
     position = ugui.joystick({
-        uid = 55,
+        uid = 700,
         margin = '20px 200px',
         size = '150px 150px',
         position = position,
     })
 
     index = ugui.listbox({
-        uid = 65,
+        uid = 800,
         margin = '20px 300px',
         size = '120px 200px',
         items = items,
         selected_index = index,
     })
     value = ugui.scrollbar({
-        uid = 75,
+        uid = 900,
         margin = '230px 10px',
         size = '20px 300px',
         value = value,
         ratio = 0.2,
     })
     value = ugui.scrollbar({
-        uid = 85,
+        uid = 1000,
         margin = '280px 10px',
         size = '300px 20px',
         value = value,
         ratio = 0.2,
     })
     index = ugui.combobox({
-        uid = 95,
+        uid = 1100,
         margin = '200px 300px',
         size = '160px 23px',
         items = items,
         selected_index = index,
     })
     ugui.joystick({
-        uid = 105,
+        uid = 1200,
         margin = '200px 350px',
         size = '150px 150px',
         position = {
@@ -114,7 +114,7 @@ emu.atdrawd2d(function()
         },
     })
     ugui.joystick({
-        uid = 115,
+        uid = 1300,
         margin = '355px 350px',
         size = '150px 150px',
         position = {
@@ -123,7 +123,7 @@ emu.atdrawd2d(function()
         },
     })
     index = ugui.carrousel_button({
-        uid = 125,
+        uid = 1400,
         margin = '380px 300px',
         size = '160px 23px',
         items = items,
@@ -131,7 +131,7 @@ emu.atdrawd2d(function()
     })
 
     num = ugui.numberbox({
-        uid = 135,
+        uid = 1500,
         margin = '350px 50px',
         size = '160px 23px',
         value = num,
@@ -146,7 +146,7 @@ emu.atdrawd2d(function()
         font_size = ugui.standard_styler.params.font_size,
     })
     num2 = ugui.numberbox({
-        uid = 145,
+        uid = 1600,
         margin = '350px 75px',
         size = '160px 23px',
         value = num2,
@@ -162,7 +162,7 @@ emu.atdrawd2d(function()
         font_size = ugui.standard_styler.params.font_size,
     })
     ugui.label({
-        uid = 155,
+        uid = 1700,
         margin = '350px 150px',
         size = '160px 23px',
         text = 'Hello World!',
@@ -171,7 +171,7 @@ emu.atdrawd2d(function()
         font_size = 24,
     })
     ugui.label({
-        uid = 165,
+        uid = 1800,
         margin = '350px 180px',
         size = '160px 23px',
         text = 'Hello World!',
@@ -181,7 +181,7 @@ emu.atdrawd2d(function()
         hittestable = true,
     })
     index = ugui.combobox({
-        uid = 175,
+        uid = 1900,
         margin = '350px 230px',
         size = '160px 23px',
         items = items,
@@ -189,89 +189,89 @@ emu.atdrawd2d(function()
         editable = true,
     })
     ugui.listbox({
-        uid = 185,
+        uid = 2000,
         margin = '560px 230px',
         size = '160px 160px',
         items = {},
         selected_index = 1,
     })
     ugui.listbox({
-        uid = 195,
+        uid = 2100,
         margin = '560px 360px',
         size = '160px 160px',
         items = {'a'},
         selected_index = nil,
     })
     if ugui.button({
-            uid = 210,
+            uid = 2200,
             margin = '620px 10px',
             size = '200px 200px',
             text = '',
         }, function()
             ugui.button({
-                uid = 220,
+                uid = 2300,
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'top left',
             })
             ugui.button({
-                uid = 230,
+                uid = 2400,
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'top center',
                 align = 'center top',
             })
             ugui.button({
-                uid = 240,
+                uid = 2500,
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'top right',
                 align = 'right top',
             })
             ugui.button({
-                uid = 250,
+                uid = 2600,
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'bottom left',
                 align = 'left bottom',
             })
             ugui.button({
-                uid = 260,
+                uid = 2700,
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'bottom center',
                 align = 'center bottom',
             })
             ugui.button({
-                uid = 270,
+                uid = 2800,
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'bottom right',
                 align = 'right bottom',
             })
             ugui.button({
-                uid = 280,
+                uid = 2900,
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'left center',
                 align = 'left center',
             })
             ugui.button({
-                uid = 290,
+                uid = 3000,
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'right center',
                 align = 'right center',
             })
             ugui.button({
-                uid = 300,
+                uid = 3100,
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'center',
                 align = 'center',
             })
             ugui.button({
-                uid = 310,
+                uid = 3200,
                 margin = '0px 0px',
                 size = '50px 23px',
                 text = 'smooth',
@@ -281,19 +281,19 @@ emu.atdrawd2d(function()
         index = index + 1
     end
     if ugui.button({
-            uid = 320,
+            uid = 3300,
             margin = '650px 220px',
             size = '200px',
             text = '',
             is_enabled = false,
         }, function()
             ugui.button({
-                uid = 330,
+                uid = 3400,
                 text = 'half width',
                 size = '0.5 23px',
             })
             ugui.button({
-                uid = 340,
+                uid = 3500,
                 text = 'half\nheight',
                 size = '23px 0.5',
                 align = '50% 100%',

--- a/demos/overlapping_controls.lua
+++ b/demos/overlapping_controls.lua
@@ -258,7 +258,7 @@ emu.atdrawd2d(function()
             margin = '650px 220px',
             size = '200px',
             text = '',
-            is_enabled = false
+            is_enabled = false,
         }, function()
             ugui.button({
                 uid = 330,

--- a/demos/overlapping_controls.lua
+++ b/demos/overlapping_controls.lua
@@ -138,8 +138,7 @@ emu.atdrawd2d(function()
         places = 4,
     })
     BreitbandGraphics.draw_text2({
-        margin = '515px 50px',
-        size = '999px 23px',
+        rectangle = {x = 515, y = 50, width = 999, height = 23},
         align_x = BreitbandGraphics.alignment.start,
         text = tostring(num),
         color = BreitbandGraphics.colors.black,
@@ -155,8 +154,7 @@ emu.atdrawd2d(function()
         show_negative = true,
     })
     BreitbandGraphics.draw_text2({
-        margin = '515px 75px',
-        size = '999px 23px',
+        rectangle = {x = 515, y = 75, width = 999, height = 23},
         align_x = BreitbandGraphics.alignment.start,
         text = tostring(num2),
         color = BreitbandGraphics.colors.black,

--- a/demos/overlapping_controls.lua
+++ b/demos/overlapping_controls.lua
@@ -259,7 +259,18 @@ emu.atdrawd2d(function()
             size = '200px',
             text = '',
         }, function()
-
+            ugui.button({
+                uid = 330,
+                text = 'half width',
+                size = '50% 23px',
+            })
+            ugui.button({
+                uid = 340,
+                text = 'half\nheight',
+                size = '23px 50%',
+                x_align = 0.5,
+                y_align = 1,
+            })
         end) then
         index = index + 1
     end

--- a/demos/overlapping_controls.lua
+++ b/demos/overlapping_controls.lua
@@ -14,6 +14,8 @@ for i = 1, 100, 1 do
     items[#items + 1] = 'Item ' .. i
 end
 
+ugui.DEBUG = true
+
 emu.atdrawd2d(function()
     begin_frame()
 
@@ -26,9 +28,15 @@ emu.atdrawd2d(function()
     end
     if ugui.button({
             uid = 15,
-            rectangle = {x = 80, y = 80, width = 100, height = 50},
+            rectangle = {x = 80 + math.sin(os.clock() * 5) * 10, y = 80 + math.cos(os.clock() * 5) * 10, width = 100, height = 50},
             text = tostring(index),
-        }) then
+        }, function()
+            ugui.button({
+                uid = 999999,
+                rectangle = {x = 10, y = 10, width = 20, height = 20},
+                text = '😀',
+            })
+        end) then
         index = index + 1
     end
     if ugui.button({
@@ -152,7 +160,7 @@ emu.atdrawd2d(function()
         color = BreitbandGraphics.colors.black,
         font_name = 'Consolas',
         font_size = 24,
-        hittestable = true
+        hittestable = true,
     })
     index = ugui.combobox({
         uid = 175,

--- a/demos/richtext.lua
+++ b/demos/richtext.lua
@@ -15,7 +15,7 @@ emu.atdrawd2d(function()
     begin_frame()
 
     ugui.button({
-        uid = 1,
+        uid = 100,
         rectangle = {x = 20, y = 20, width = 100, height = 100},
         text = '[icon:arrow_left]Go Back',
         tooltip = 'In the [icon:arrow_up] middle',
@@ -23,7 +23,7 @@ emu.atdrawd2d(function()
     })
 
     align_x = ugui.combobox({
-        uid = 5,
+        uid = 200,
         rectangle = {x = 200, y = 20, width = 90, height = 20},
         items = alignments,
         selected_index = align_x,
@@ -31,7 +31,7 @@ emu.atdrawd2d(function()
     })
 
     align_y = ugui.combobox({
-        uid = 10,
+        uid = 300,
         rectangle = {x = 200, y = 100, width = 90, height = 20},
         items = alignments,
         selected_index = align_y,
@@ -39,7 +39,7 @@ emu.atdrawd2d(function()
     })
 
     plaintext = ugui.toggle_button({
-        uid = 15,
+        uid = 400,
         rectangle = {x = 200, y = 130, width = 90, height = 20},
         text = 'Plaintext',
         is_checked = plaintext,
@@ -47,7 +47,7 @@ emu.atdrawd2d(function()
     })
 
     ugui.listbox({
-        uid = 20,
+        uid = 500,
         rectangle = {x = 200, y = 160, width = 140, height = 300},
         items = {
             '[icon:arrow_up] Hello',

--- a/demos/stress_test.lua
+++ b/demos/stress_test.lua
@@ -17,7 +17,7 @@ emu.atdrawd2d(function()
             } or nil
 
             ugui.button({
-                uid = i,
+                uid = (i + 1) * 100,
                 rectangle = {
                     x = (x - 1) * 20,
                     y = (y - 1) * 20,

--- a/demos/tooltips.lua
+++ b/demos/tooltips.lua
@@ -5,7 +5,7 @@ emu.atdrawd2d(function()
     begin_frame()
 
     ugui.combobox({
-        uid = 1,
+        uid = 10,
         rectangle = {x = 10, y = 10, width = 90, height = 20},
         items = {
             'Hello',
@@ -19,27 +19,27 @@ emu.atdrawd2d(function()
     })
 
     ugui.button({
-        uid = 3,
+        uid = 20,
         rectangle = {x = 0, y = 35, width = 800, height = 20},
         text = 'Hover Here',
         tooltip = 'Hello World!',
     })
 
     ugui.button({
-        uid = 4,
+        uid = 30,
         rectangle = {x = 10, y = 60, width = 90, height = 20},
         text = 'Hover Here',
         tooltip = 'Voluptas culpa officia consequatur eveniet. Sint fugiat culpa rerum debitis. Et ea cupiditate nulla eius saepe minima. Aspernatur omnis ut amet incidunt sequi doloremque corrupti. Corrupti vero quae rerum est recusandae perferendis.',
     })
 
     ugui.button({
-        uid = 76,
+        uid = 40,
         rectangle = {x = 10, y = 90, width = 90, height = 20},
         text = 'Im boring',
     })
 
     ugui.button({
-        uid = 80,
+        uid = 50,
         rectangle = {x = 10, y = 120, width = 90, height = 20},
         is_enabled = false,
         text = 'nope',
@@ -47,7 +47,7 @@ emu.atdrawd2d(function()
     })
 
     ugui.button({
-        uid = 5,
+        uid = 60,
         rectangle = {x = 700, y = 540, width = 90, height = 50},
         text = 'Hover Here',
         tooltip = 'Wow.',

--- a/demos/tooltips.lua
+++ b/demos/tooltips.lua
@@ -5,7 +5,7 @@ emu.atdrawd2d(function()
     begin_frame()
 
     ugui.combobox({
-        uid = 10,
+        uid = 100,
         rectangle = {x = 10, y = 10, width = 90, height = 20},
         items = {
             'Hello',
@@ -19,27 +19,27 @@ emu.atdrawd2d(function()
     })
 
     ugui.button({
-        uid = 20,
+        uid = 200,
         rectangle = {x = 0, y = 35, width = 800, height = 20},
         text = 'Hover Here',
         tooltip = 'Hello World!',
     })
 
     ugui.button({
-        uid = 30,
+        uid = 300,
         rectangle = {x = 10, y = 60, width = 90, height = 20},
         text = 'Hover Here',
         tooltip = 'Voluptas culpa officia consequatur eveniet. Sint fugiat culpa rerum debitis. Et ea cupiditate nulla eius saepe minima. Aspernatur omnis ut amet incidunt sequi doloremque corrupti. Corrupti vero quae rerum est recusandae perferendis.',
     })
 
     ugui.button({
-        uid = 40,
+        uid = 400,
         rectangle = {x = 10, y = 90, width = 90, height = 20},
         text = 'Im boring',
     })
 
     ugui.button({
-        uid = 50,
+        uid = 500,
         rectangle = {x = 10, y = 120, width = 90, height = 20},
         is_enabled = false,
         text = 'nope',
@@ -47,7 +47,7 @@ emu.atdrawd2d(function()
     })
 
     ugui.button({
-        uid = 60,
+        uid = 600,
         rectangle = {x = 700, y = 540, width = 90, height = 50},
         text = 'Hover Here',
         tooltip = 'Wow.',

--- a/demos/ugui_ext.lua
+++ b/demos/ugui_ext.lua
@@ -8,7 +8,7 @@ emu.atdrawd2d(function()
     begin_frame()
 
     value = ugui.spinner({
-        uid = 1,
+        uid = 100,
         rectangle = {
             x = 5,
             y = 10,
@@ -19,7 +19,7 @@ emu.atdrawd2d(function()
     })
 
     local result = ugui.tabcontrol({
-        uid = 5,
+        uid = 200,
         rectangle = {
             x = 5,
             y = 40,
@@ -35,7 +35,7 @@ emu.atdrawd2d(function()
     })
 
     value = ugui.numberbox({
-        uid = 10,
+        uid = 300,
         rectangle = {
             x = 5,
             y = 250,

--- a/src/ugui/controls/button.lua
+++ b/src/ugui/controls/button.lua
@@ -44,7 +44,7 @@ ugui.button = function(control, fn)
         ugui.label({
             uid = control.uid + 1,
             text = control.text,
-            align = '50%',
+            align = '0.5',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
         if fn then

--- a/src/ugui/controls/button.lua
+++ b/src/ugui/controls/button.lua
@@ -44,8 +44,7 @@ ugui.button = function(control, fn)
         ugui.label({
             uid = control.uid + 1,
             text = control.text,
-            x_align = 0.5,
-            y_align = 0.5,
+            align = '50%',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
         if fn then

--- a/src/ugui/controls/button.lua
+++ b/src/ugui/controls/button.lua
@@ -39,6 +39,18 @@ ugui.registry.button = {
 ---@param fn fun()? The function to immediately invoke upon placing the button. In the function's context, any placed controls will be parented to this control.
 ---@return boolean, Meta # Whether the button has been pressed.
 ugui.button = function(control, fn)
-    local result = ugui.control(control, 'button', fn)
+    local result = ugui.control(control, 'button', function()
+        local visual_state = ugui.get_visual_state(control)
+        ugui.label({
+            uid = control.uid + 1,
+            text = control.text,
+            x_align = 0.5,
+            y_align = 0.5,
+            color = ugui.standard_styler.params.button.text[visual_state],
+        })
+        if fn then
+            fn()
+        end
+    end)
     return result.primary, result.meta
 end

--- a/src/ugui/controls/button.lua
+++ b/src/ugui/controls/button.lua
@@ -36,8 +36,9 @@ ugui.registry.button = {
 
 ---Places a Button.
 ---@param control Button The control table.
+---@param fn fun()? The function to immediately invoke upon placing the button. In the function's context, any placed controls will be parented to this control.
 ---@return boolean, Meta # Whether the button has been pressed.
-ugui.button = function(control)
-    local result = ugui.control(control, 'button')
+ugui.button = function(control, fn)
+    local result = ugui.control(control, 'button', fn)
     return result.primary, result.meta
 end

--- a/src/ugui/controls/carrousel_button.lua
+++ b/src/ugui/controls/carrousel_button.lua
@@ -57,8 +57,9 @@ ugui.registry.carrousel_button = {
 
 ---Places a CarrouselButton.
 ---@param control CarrouselButton The control table.
+---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return integer, Meta # The new selected index.
-ugui.carrousel_button = function(control)
-    local result = ugui.control(control, 'carrousel_button')
+ugui.carrousel_button = function(control, fn)
+    local result = ugui.control(control, 'carrousel_button', fn)
     return result.primary, result.meta
 end

--- a/src/ugui/controls/carrousel_button.lua
+++ b/src/ugui/controls/carrousel_button.lua
@@ -60,25 +60,29 @@ ugui.registry.carrousel_button = {
 ---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return integer, Meta # The new selected index.
 ugui.carrousel_button = function(control, fn)
+    local label_1_uid<const> = control.uid + 1
+    local label_2_uid<const> = control.uid + 2
+    local label_3_uid<const> = control.uid + 3
+
     local result = ugui.control(control, 'carrousel_button', function()
         local visual_state = ugui.get_visual_state(control)
         local text = control.selected_index and control.items[control.selected_index] or ''
 
         ugui.label({
-            uid = control.uid + 1,
+            uid = label_1_uid,
             text = '[icon:arrow_left]',
             margin = string.format('%dpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
             align = '0% 50%',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
         ugui.label({
-            uid = control.uid + 2,
+            uid = label_2_uid,
             text = text,
             align = '50%',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
         ugui.label({
-            uid = control.uid + 3,
+            uid = label_3_uid,
             text = '[icon:arrow_right]',
             margin = string.format('-%dpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
             align = '100% 50%',

--- a/src/ugui/controls/carrousel_button.lua
+++ b/src/ugui/controls/carrousel_button.lua
@@ -72,20 +72,22 @@ ugui.carrousel_button = function(control, fn)
             uid = label_1_uid,
             text = '[icon:arrow_left]',
             margin = string.format('%dpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
-            align = '0% 50%',
+            align = '0 0.5',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
+
         ugui.label({
             uid = label_2_uid,
             text = text,
-            align = '50%',
+            align = '0.5',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
+
         ugui.label({
             uid = label_3_uid,
             text = '[icon:arrow_right]',
             margin = string.format('-%dpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
-            align = '100% 50%',
+            align = '1 0.5',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
         if fn then

--- a/src/ugui/controls/carrousel_button.lua
+++ b/src/ugui/controls/carrousel_button.lua
@@ -23,8 +23,8 @@ ugui.registry.carrousel_button = {
         data.selected_index = control.selected_index
 
         if ugui.internal.clicked_control == control.uid then
-            local relative_x = ugui.internal.environment.mouse_position.x - control.rectangle.x
-            if relative_x > control.rectangle.width / 2 then
+            local relative_x = ugui.internal.environment.mouse_position.x - data.render_rect.x
+            if relative_x > data.render_rect.width / 2 then
                 data.selected_index = data.selected_index + 1
                 if data.selected_index > #control.items then
                     data.selected_index = 1

--- a/src/ugui/controls/carrousel_button.lua
+++ b/src/ugui/controls/carrousel_button.lua
@@ -60,6 +60,36 @@ ugui.registry.carrousel_button = {
 ---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return integer, Meta # The new selected index.
 ugui.carrousel_button = function(control, fn)
-    local result = ugui.control(control, 'carrousel_button', fn)
+    local result = ugui.control(control, 'carrousel_button', function()
+        local visual_state = ugui.get_visual_state(control)
+        local text = control.selected_index and control.items[control.selected_index] or ''
+
+        ugui.label({
+            uid = control.uid + 1,
+            text = '[icon:arrow_left]',
+            margin = string.format('%dpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
+            x_align = 0,
+            y_align = 0.5,
+            color = ugui.standard_styler.params.button.text[visual_state],
+        })
+        ugui.label({
+            uid = control.uid + 2,
+            text = text,
+            x_align = 0.5,
+            y_align = 0.5,
+            color = ugui.standard_styler.params.button.text[visual_state],
+        })
+        ugui.label({
+            uid = control.uid + 3,
+            text = '[icon:arrow_right]',
+            margin = string.format('-%dpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
+            x_align = 1,
+            y_align = 0.5,
+            color = ugui.standard_styler.params.button.text[visual_state],
+        })
+        if fn then
+            fn()
+        end
+    end)
     return result.primary, result.meta
 end

--- a/src/ugui/controls/carrousel_button.lua
+++ b/src/ugui/controls/carrousel_button.lua
@@ -68,23 +68,20 @@ ugui.carrousel_button = function(control, fn)
             uid = control.uid + 1,
             text = '[icon:arrow_left]',
             margin = string.format('%dpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
-            x_align = 0,
-            y_align = 0.5,
+            align = '0% 50%',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
         ugui.label({
             uid = control.uid + 2,
             text = text,
-            x_align = 0.5,
-            y_align = 0.5,
+            align = '50%',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
         ugui.label({
             uid = control.uid + 3,
             text = '[icon:arrow_right]',
             margin = string.format('-%dpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
-            x_align = 1,
-            y_align = 0.5,
+            align = '100% 50%',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
         if fn then

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -37,17 +37,6 @@ ugui.registry.combobox = {
             data.open = not data.open
         end
 
-        if data.open and ugui.internal.is_mouse_just_down() and not ugui.internal.is_point_inside_control(ugui.internal.environment.mouse_position, control) then
-            -- fixme
-            -- if not BreitbandGraphics.is_point_inside_rectangle(ugui.internal.environment.mouse_position, {
-            --         x = control.rectangle.x,
-            --         y = control.rectangle.y + control.rectangle.height,
-            --         width = control.rectangle.width,
-            --         height = content_bounds.height,
-            --     }) then
-            --     data.open = false
-            -- end
-        end
 
         data.signal_change = ugui.internal.process_signal_changes(data.signal_change,
             control.selected_index ~= data.selected_index)
@@ -84,14 +73,14 @@ ugui.combobox = function(control, fn)
         ugui.label({
             uid = label_1_uid,
             text = text,
-            margin = string.format('%dpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
+            margin = string.format('%fpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
             align = '0% 50%',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
         ugui.label({
             uid = label_2_uid,
             text = data.open and '[icon:arrow_up]' or '[icon:arrow_down]',
-            margin = string.format('-%dpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
+            margin = string.format('-%fpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
             align = '100% 50%',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
@@ -171,42 +160,29 @@ ugui.combobox = function(control, fn)
         end
 
         if data.open then
-            -- fixme
-            -- local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
+            local dropdown_x<const> = data.render_rect.x
+            local dropdown_y<const> = data.render_rect.y + data.render_rect.height
+            local dropdown_width<const> = data.render_rect.width
 
-            -- local width = control.rectangle.width
-            -- if control.rectangle.x + width > ugui.internal.environment.window_size.x then
-            --     width = ugui.internal.environment.window_size.x - control.rectangle.x
-            -- end
+            local prev_parent = ugui.internal.current_parent
+            ugui.internal.current_parent = ugui.internal.root
+            local listbox_result, meta_listbox = ugui.listbox({
+                uid = listbox_uid,
+                margin = string.format('%fpx %fpx', dropdown_x, dropdown_y),
+                size = string.format('%fpx auto', dropdown_width),
+                items = items_to_show,
+                selected_index = data.selected_index,
+                plaintext = control.plaintext,
+                z_index = math.maxinteger,
+            })
+            ugui.internal.current_parent = prev_parent
 
-            -- local height = content_bounds.height
-            -- if control.rectangle.y + height > ugui.internal.environment.window_size.y then
-            --     height = ugui.internal.environment.window_size.y - control.rectangle.y -
-            --         ugui.standard_styler.params.listbox_item.height * 2
-            -- end
-
-            -- local list_rect = {
-            --     x = control.rectangle.x,
-            --     y = control.rectangle.y + control.rectangle.height,
-            --     width = width,
-            --     height = height,
-            -- }
-
-            -- local listbox_result, meta_listbox = ugui.listbox({
-            --     uid = listbox_uid,
-            --     rectangle = list_rect,
-            --     items = items_to_show,
-            --     selected_index = data.selected_index,
-            --     plaintext = control.plaintext,
-            --     z_index = math.maxinteger,
-            -- })
-
-            -- if meta_listbox.signal_change == ugui.signal_change_states.started then
-            --     data.selected_index = filtered_to_original and filtered_to_original[listbox_result] or listbox_result
-            --     data.searching = false
-            --     data.search_text = ''
-            --     data.open = false
-            -- end
+            if meta_listbox.signal_change == ugui.signal_change_states.started then
+                data.selected_index = filtered_to_original and filtered_to_original[listbox_result] or listbox_result
+                data.searching = false
+                data.search_text = ''
+                data.open = false
+            end
         end
     end
 

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -113,10 +113,10 @@ ugui.combobox = function(control, fn)
         local search_text = ugui.textbox({
             uid = textbox_uid,
             rectangle = {
-                x = control.rectangle.x,
-                y = control.rectangle.y,
-                width = control.rectangle.width - button_size,
-                height = control.rectangle.height,
+                x = data.render_rect.x,
+                y = data.render_rect.y,
+                width = data.render_rect.width - button_size,
+                height = data.render_rect.height,
             },
             is_enabled = control.is_enabled,
             text = current_text,
@@ -125,10 +125,10 @@ ugui.combobox = function(control, fn)
         if ugui.button({
                 uid = button_uid,
                 rectangle = {
-                    x = control.rectangle.x + control.rectangle.width - button_size,
-                    y = control.rectangle.y,
+                    x = data.render_rect.x + data.render_rect.width - button_size,
+                    y = data.render_rect.y,
                     width = button_size,
-                    height = control.rectangle.height,
+                    height = data.render_rect.height,
                 },
                 is_enabled = control.is_enabled,
                 text = data.open and '[icon:arrow_up]' or '[icon:arrow_down]',
@@ -177,20 +177,20 @@ ugui.combobox = function(control, fn)
 
         local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
 
-        local width = control.rectangle.width
-        if control.rectangle.x + width > ugui.internal.environment.window_size.x then
-            width = ugui.internal.environment.window_size.x - control.rectangle.x
+        local width = data.render_rect.width
+        if data.render_rect.x + width > ugui.internal.environment.window_size.x then
+            width = ugui.internal.environment.window_size.x - data.render_rect.x
         end
 
         local height = content_bounds.height
-        if control.rectangle.y + height > ugui.internal.environment.window_size.y then
-            height = ugui.internal.environment.window_size.y - control.rectangle.y -
+        if data.render_rect.y + height > ugui.internal.environment.window_size.y then
+            height = ugui.internal.environment.window_size.y - data.render_rect.y -
                 ugui.standard_styler.params.listbox_item.height * 2
         end
 
         local list_rect = {
-            x = control.rectangle.x,
-            y = control.rectangle.y + control.rectangle.height,
+            x = data.render_rect.x,
+            y = data.render_rect.y + data.render_rect.height,
             width = width,
             height = height,
         }

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -78,6 +78,7 @@ ugui.combobox = function(control, fn)
         ugui.label({
             uid = control.uid + 4,
             text = text,
+            margin = string.format('%dpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
             x_align = 0,
             y_align = 0.5,
             color = ugui.standard_styler.params.button.text[visual_state],
@@ -85,6 +86,7 @@ ugui.combobox = function(control, fn)
         ugui.label({
             uid = control.uid + 5,
             text = data.open and '[icon:arrow_up]' or '[icon:arrow_down]',
+            margin = string.format('-%dpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
             x_align = 1,
             y_align = 0.5,
             color = ugui.standard_styler.params.button.text[visual_state],

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -176,31 +176,12 @@ ugui.combobox = function(control, fn)
             data.filtered_to_original = nil
         end
 
-        local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
-
-        local width = data.render_rect.width
-        if data.render_rect.x + width > ugui.internal.environment.window_size.x then
-            width = ugui.internal.environment.window_size.x - data.render_rect.x
-        end
-
-        local height = content_bounds.height
-        if data.render_rect.y + height > ugui.internal.environment.window_size.y then
-            height = ugui.internal.environment.window_size.y - data.render_rect.y -
-                ugui.standard_styler.params.listbox_item.height * 2
-        end
-
-        local list_rect = {
-            x = data.render_rect.x,
-            y = data.render_rect.y + data.render_rect.height,
-            width = width,
-            height = height,
-        }
-
         local restore = ugui.internal.keyboard_captured_control
         ugui.internal.keyboard_captured_control = listbox_uid
         local listbox = {
             uid = listbox_uid,
-            rectangle = list_rect,
+            margin = string.format('%fpx %fpx', data.render_rect.x, data.render_rect.y + data.render_rect.height),
+            size = string.format('%fpx auto', data.render_rect.width), -- FIXME: This needs overflow prevention
             items = items_to_show,
             selected_index = data.selected_index,
             plaintext = control.plaintext,

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -69,6 +69,12 @@ ugui.registry.combobox = {
 ---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return integer, Meta # The new selected index.
 ugui.combobox = function(control, fn)
+    local textbox_uid<const> = control.uid + 1
+    local button_uid<const> = control.uid + 2
+    local listbox_uid<const> = control.uid + 4
+    local label_1_uid<const> = control.uid + 7
+    local label_2_uid<const> = control.uid + 8
+
     local result = ugui.control(control, 'combobox', function()
         local visual_state = ugui.get_visual_state(control)
 
@@ -76,14 +82,14 @@ ugui.combobox = function(control, fn)
         local text = control.selected_index and control.items[control.selected_index] or ''
 
         ugui.label({
-            uid = control.uid + 4,
+            uid = label_1_uid,
             text = text,
             margin = string.format('%dpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
             align = '0% 50%',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
         ugui.label({
-            uid = control.uid + 5,
+            uid = label_2_uid,
             text = data.open and '[icon:arrow_up]' or '[icon:arrow_down]',
             margin = string.format('-%dpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
             align = '100% 50%',
@@ -94,10 +100,6 @@ ugui.combobox = function(control, fn)
         end
     end)
     local data = ugui.internal.control_data[control.uid]
-
-    local textbox_uid<const> = control.uid + 1
-    local button_uid<const> = control.uid + 2
-    local listbox_uid<const> = control.uid + 3
 
     local button_size<const> = 30
 

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -79,16 +79,14 @@ ugui.combobox = function(control, fn)
             uid = control.uid + 4,
             text = text,
             margin = string.format('%dpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
-            x_align = 0,
-            y_align = 0.5,
+            align = '0% 50%',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
         ugui.label({
             uid = control.uid + 5,
             text = data.open and '[icon:arrow_up]' or '[icon:arrow_down]',
             margin = string.format('-%dpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
-            x_align = 1,
-            y_align = 0.5,
+            align = '100% 50%',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
         if fn then

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -38,15 +38,15 @@ ugui.registry.combobox = {
         end
 
         if data.open and ugui.internal.is_mouse_just_down() and not ugui.internal.is_point_inside_control(ugui.internal.environment.mouse_position, control) then
-            local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
-            if not BreitbandGraphics.is_point_inside_rectangle(ugui.internal.environment.mouse_position, {
-                    x = control.rectangle.x,
-                    y = control.rectangle.y + control.rectangle.height,
-                    width = control.rectangle.width,
-                    height = content_bounds.height,
-                }) then
-                data.open = false
-            end
+            -- fixme
+            -- if not BreitbandGraphics.is_point_inside_rectangle(ugui.internal.environment.mouse_position, {
+            --         x = control.rectangle.x,
+            --         y = control.rectangle.y + control.rectangle.height,
+            --         width = control.rectangle.width,
+            --         height = content_bounds.height,
+            --     }) then
+            --     data.open = false
+            -- end
         end
 
         data.signal_change = ugui.internal.process_signal_changes(data.signal_change,
@@ -171,41 +171,42 @@ ugui.combobox = function(control, fn)
         end
 
         if data.open then
-            local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
+            -- fixme
+            -- local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
 
-            local width = control.rectangle.width
-            if control.rectangle.x + width > ugui.internal.environment.window_size.x then
-                width = ugui.internal.environment.window_size.x - control.rectangle.x
-            end
+            -- local width = control.rectangle.width
+            -- if control.rectangle.x + width > ugui.internal.environment.window_size.x then
+            --     width = ugui.internal.environment.window_size.x - control.rectangle.x
+            -- end
 
-            local height = content_bounds.height
-            if control.rectangle.y + height > ugui.internal.environment.window_size.y then
-                height = ugui.internal.environment.window_size.y - control.rectangle.y -
-                    ugui.standard_styler.params.listbox_item.height * 2
-            end
+            -- local height = content_bounds.height
+            -- if control.rectangle.y + height > ugui.internal.environment.window_size.y then
+            --     height = ugui.internal.environment.window_size.y - control.rectangle.y -
+            --         ugui.standard_styler.params.listbox_item.height * 2
+            -- end
 
-            local list_rect = {
-                x = control.rectangle.x,
-                y = control.rectangle.y + control.rectangle.height,
-                width = width,
-                height = height,
-            }
+            -- local list_rect = {
+            --     x = control.rectangle.x,
+            --     y = control.rectangle.y + control.rectangle.height,
+            --     width = width,
+            --     height = height,
+            -- }
 
-            local listbox_result, meta_listbox = ugui.listbox({
-                uid = listbox_uid,
-                rectangle = list_rect,
-                items = items_to_show,
-                selected_index = data.selected_index,
-                plaintext = control.plaintext,
-                z_index = math.maxinteger,
-            })
+            -- local listbox_result, meta_listbox = ugui.listbox({
+            --     uid = listbox_uid,
+            --     rectangle = list_rect,
+            --     items = items_to_show,
+            --     selected_index = data.selected_index,
+            --     plaintext = control.plaintext,
+            --     z_index = math.maxinteger,
+            -- })
 
-            if meta_listbox.signal_change == ugui.signal_change_states.started then
-                data.selected_index = filtered_to_original and filtered_to_original[listbox_result] or listbox_result
-                data.searching = false
-                data.search_text = ''
-                data.open = false
-            end
+            -- if meta_listbox.signal_change == ugui.signal_change_states.started then
+            --     data.selected_index = filtered_to_original and filtered_to_original[listbox_result] or listbox_result
+            --     data.searching = false
+            --     data.search_text = ''
+            --     data.open = false
+            -- end
         end
     end
 

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -86,14 +86,15 @@ ugui.combobox = function(control, fn)
             uid = label_1_uid,
             text = text,
             margin = string.format('%fpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
-            align = '0% 50%',
+            align = '0 0.5',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
+
         ugui.label({
             uid = label_2_uid,
             text = data.open and '[icon:arrow_up]' or '[icon:arrow_down]',
             margin = string.format('-%fpx 0', ugui.standard_styler.params.textbox.padding.x * 2),
-            align = '100% 50%',
+            align = '1 0.5',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
         if fn then

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -69,7 +69,30 @@ ugui.registry.combobox = {
 ---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return integer, Meta # The new selected index.
 ugui.combobox = function(control, fn)
-    local result = ugui.control(control, 'combobox', fn)
+    local result = ugui.control(control, 'combobox', function()
+        local visual_state = ugui.get_visual_state(control)
+
+        local data = ugui.internal.control_data[control.uid]
+        local text = control.selected_index and control.items[control.selected_index] or ''
+
+        ugui.label({
+            uid = control.uid + 4,
+            text = text,
+            x_align = 0,
+            y_align = 0.5,
+            color = ugui.standard_styler.params.button.text[visual_state],
+        })
+        ugui.label({
+            uid = control.uid + 5,
+            text = data.open and '[icon:arrow_up]' or '[icon:arrow_down]',
+            x_align = 1,
+            y_align = 0.5,
+            color = ugui.standard_styler.params.button.text[visual_state],
+        })
+        if fn then
+            fn()
+        end
+    end)
     local data = ugui.internal.control_data[control.uid]
 
     local textbox_uid<const> = control.uid + 1

--- a/src/ugui/controls/combobox.lua
+++ b/src/ugui/controls/combobox.lua
@@ -66,9 +66,10 @@ ugui.registry.combobox = {
 
 ---Places a ComboBox.
 ---@param control ComboBox The control table.
+---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return integer, Meta # The new selected index.
-ugui.combobox = function(control)
-    local result = ugui.control(control, 'combobox')
+ugui.combobox = function(control, fn)
+    local result = ugui.control(control, 'combobox', fn)
     local data = ugui.internal.control_data[control.uid]
 
     local textbox_uid<const> = control.uid + 1

--- a/src/ugui/controls/control.lua
+++ b/src/ugui/controls/control.lua
@@ -7,7 +7,7 @@
 ---@class Control
 ---@field public uid UID The unique identifier of the control.
 ---@field public styler_mixin any? An optional styler mixin table which can override specific styler parameters for this control.
----@field public rectangle Rectangle? **DEPRECATED - Use x/y/width/height instead.** A rectangle defining the control's position and size. The position is treated as an offset from the parent's position, while the size is treated as a forced value.
+---@field public rectangle Rectangle? **DEPRECATED - Use `margin`/`size` instead.** A rectangle defining the control's position and size. The position is treated as an offset from the parent's position, while the size is treated as a forced value.
 ---@field public is_enabled boolean? Whether the control is enabled. If nil or true, the control is enabled.
 ---@field public margin SmartUnit2? The control's margin. If nil, `rectangle` is used. If both are nil, `0px` is assumed.
 ---@field public size SmartUnit2? The control's size. If nil, `rectangle` is used. If both are nil, `auto` is assumed.

--- a/src/ugui/controls/control.lua
+++ b/src/ugui/controls/control.lua
@@ -11,8 +11,7 @@
 ---@field public is_enabled boolean? Whether the control is enabled. If nil or true, the control is enabled.
 ---@field public margin SmartUnit2? The control's margin. If `nil`, `0px` is assumed.
 ---@field public size SmartUnit2? The control's size. If `nil`, `auto` is assumed.
----@field public x_align number? The horizontal alignment of the control within its parent in range `0` to `1`, where `0` is left-aligned and `1` is right-aligned. If nil, `0` is assumed. The `rectangle` X offset is applied after alignment.
----@field public y_align number? The vertical alignment of the control within its parent in range `0` to `1`, where `0` is top-aligned and `1` is bottom-aligned. If nil, `0` is assumed. The `rectangle` Y offset is applied after alignment.
+---@field public align SmartAlignment2? The control's alignment within its parent. If `nil`, `0 0` is assumed.
 ---@field public tooltip string? The control's tooltip. If nil, no tooltip will be shown.
 ---@field public plaintext boolean? Whether the control's text content is drawn as plain text without rich rendering.
 ---@field public z_index integer? The control's Z-index. If nil, `0` is assumed. This control will be drawn in front of siblings with a lower Z-index. To control the Z-index relative to all controls (including parents), parent the control to the scene root.

--- a/src/ugui/controls/control.lua
+++ b/src/ugui/controls/control.lua
@@ -7,10 +7,10 @@
 ---@class Control
 ---@field public uid UID The unique identifier of the control.
 ---@field public styler_mixin any? An optional styler mixin table which can override specific styler parameters for this control.
----@field public rectangle Rectangle? **DEPRECATED - Use `margin`/`size` instead.** A rectangle defining the control's position and size. The position is treated as an offset from the parent's position, while the size is treated as a forced value.
+---@field public rectangle Rectangle? **DEPRECATED - Use `margin`/`size` instead. Note that `rectangle` overrides `margin`/`size` when both are set.** A rectangle defining the control's position and size. The position is treated as an offset from the parent's position, while the size is treated as a forced value.
 ---@field public is_enabled boolean? Whether the control is enabled. If nil or true, the control is enabled.
----@field public margin SmartUnit2? The control's margin. If nil, `rectangle` is used. If both are nil, `0px` is assumed.
----@field public size SmartUnit2? The control's size. If nil, `rectangle` is used. If both are nil, `auto` is assumed.
+---@field public margin SmartUnit2? The control's margin. If `nil`, `0px` is assumed.
+---@field public size SmartUnit2? The control's size. If `nil`, `auto` is assumed.
 ---@field public x_align number? The horizontal alignment of the control within its parent in range `0` to `1`, where `0` is left-aligned and `1` is right-aligned. If nil, `0` is assumed. The `rectangle` X offset is applied after alignment.
 ---@field public y_align number? The vertical alignment of the control within its parent in range `0` to `1`, where `0` is top-aligned and `1` is bottom-aligned. If nil, `0` is assumed. The `rectangle` Y offset is applied after alignment.
 ---@field public tooltip string? The control's tooltip. If nil, no tooltip will be shown.

--- a/src/ugui/controls/control.lua
+++ b/src/ugui/controls/control.lua
@@ -9,9 +9,10 @@
 ---@field public styler_mixin any? An optional styler mixin table which can override specific styler parameters for this control.
 ---@field public rectangle Rectangle? **DEPRECATED - Use `margin`/`size` instead. Note that `rectangle` overrides `margin`/`size` when both are set.** A rectangle defining the control's position and size. The position is treated as an offset from the parent's position, while the size is treated as a forced value.
 ---@field public is_enabled boolean? Whether the control is enabled. If nil or true, the control is enabled.
----@field public margin SmartUnit2? The control's margin. If `nil`, `0px` is assumed.
+---@field public margin SmartUnit2? The control's margin. If `nil`, `0` is assumed.
 ---@field public size SmartUnit2? The control's size. If `nil`, `auto` is assumed.
----@field public align SmartAlignment2? The control's alignment within its parent. If `nil`, `0 0` is assumed.
+---@field public padding SmartUnit2? Padding around the control's content. If `nil`, the control default padding is used.
+---@field public align SmartAlignment2? The control's alignment within its parent. If `nil`, `0` is assumed.
 ---@field public tooltip string? The control's tooltip. If nil, no tooltip will be shown.
 ---@field public plaintext boolean? Whether the control's text content is drawn as plain text without rich rendering.
 ---@field public z_index integer? The control's Z-index. If nil, `0` is assumed. This control will be drawn in front of siblings with a lower Z-index. To control the Z-index relative to all controls (including parents), parent the control to the scene root.

--- a/src/ugui/controls/control.lua
+++ b/src/ugui/controls/control.lua
@@ -11,5 +11,5 @@
 ---@field public is_enabled boolean? Whether the control is enabled. If nil or true, the control is enabled.
 ---@field public tooltip string? The control's tooltip. If nil, no tooltip will be shown.
 ---@field public plaintext boolean? Whether the control's text content is drawn as plain text without rich rendering.
----@field public z_index integer? The control's Z-index. If nil, `0` is assumed.
+---@field public z_index integer? The control's Z-index. If nil, `0` is assumed. This control will be drawn in front of siblings with a lower Z-index. To control the Z-index relative to all controls (including parents), parent the control to the scene root.
 ---The base class for all controls.

--- a/src/ugui/controls/control.lua
+++ b/src/ugui/controls/control.lua
@@ -9,6 +9,8 @@
 ---@field public styler_mixin any? An optional styler mixin table which can override specific styler parameters for this control.
 ---@field public rectangle Rectangle The rectangle in which the control is drawn.
 ---@field public is_enabled boolean? Whether the control is enabled. If nil or true, the control is enabled.
+---@field public x_align number? The horizontal alignment of the control within its parent in range `0` to `1`, where `0` is left-aligned and `1` is right-aligned. If nil, `0` is assumed. The `rectangle` X offset is applied after alignment.
+---@field public y_align number? The vertical alignment of the control within its parent in range `0` to `1`, where `0` is top-aligned and `1` is bottom-aligned. If nil, `0` is assumed. The `rectangle` Y offset is applied after alignment.
 ---@field public tooltip string? The control's tooltip. If nil, no tooltip will be shown.
 ---@field public plaintext boolean? Whether the control's text content is drawn as plain text without rich rendering.
 ---@field public z_index integer? The control's Z-index. If nil, `0` is assumed. This control will be drawn in front of siblings with a lower Z-index. To control the Z-index relative to all controls (including parents), parent the control to the scene root.

--- a/src/ugui/controls/control.lua
+++ b/src/ugui/controls/control.lua
@@ -9,8 +9,8 @@
 ---@field public styler_mixin any? An optional styler mixin table which can override specific styler parameters for this control.
 ---@field public rectangle Rectangle? **DEPRECATED - Use x/y/width/height instead.** A rectangle defining the control's position and size. The position is treated as an offset from the parent's position, while the size is treated as a forced value.
 ---@field public is_enabled boolean? Whether the control is enabled. If nil or true, the control is enabled.
----@field public margin SmartUnit2? The control's margin. If nil, `rectangle` is used. If both are nil, `0px 0px` is assumed.
----@field public size SmartUnit2? The control's size. If nil, `rectangle` is used. If both are nil, `0px 0px` is assumed.
+---@field public margin SmartUnit2? The control's margin. If nil, `rectangle` is used. If both are nil, `0px` is assumed.
+---@field public size SmartUnit2? The control's size. If nil, `rectangle` is used. If both are nil, `auto` is assumed.
 ---@field public x_align number? The horizontal alignment of the control within its parent in range `0` to `1`, where `0` is left-aligned and `1` is right-aligned. If nil, `0` is assumed. The `rectangle` X offset is applied after alignment.
 ---@field public y_align number? The vertical alignment of the control within its parent in range `0` to `1`, where `0` is top-aligned and `1` is bottom-aligned. If nil, `0` is assumed. The `rectangle` Y offset is applied after alignment.
 ---@field public tooltip string? The control's tooltip. If nil, no tooltip will be shown.

--- a/src/ugui/controls/control.lua
+++ b/src/ugui/controls/control.lua
@@ -7,8 +7,10 @@
 ---@class Control
 ---@field public uid UID The unique identifier of the control.
 ---@field public styler_mixin any? An optional styler mixin table which can override specific styler parameters for this control.
----@field public rectangle Rectangle The rectangle in which the control is drawn.
+---@field public rectangle Rectangle? **DEPRECATED - Use x/y/width/height instead.** A rectangle defining the control's position and size. The position is treated as an offset from the parent's position, while the size is treated as a forced value.
 ---@field public is_enabled boolean? Whether the control is enabled. If nil or true, the control is enabled.
+---@field public margin SmartUnit2? The control's margin. If nil, `rectangle` is used. If both are nil, `0px 0px` is assumed.
+---@field public size SmartUnit2? The control's size. If nil, `rectangle` is used. If both are nil, `0px 0px` is assumed.
 ---@field public x_align number? The horizontal alignment of the control within its parent in range `0` to `1`, where `0` is left-aligned and `1` is right-aligned. If nil, `0` is assumed. The `rectangle` X offset is applied after alignment.
 ---@field public y_align number? The vertical alignment of the control within its parent in range `0` to `1`, where `0` is top-aligned and `1` is bottom-aligned. If nil, `0` is assumed. The `rectangle` Y offset is applied after alignment.
 ---@field public tooltip string? The control's tooltip. If nil, no tooltip will be shown.

--- a/src/ugui/controls/joystick.lua
+++ b/src/ugui/controls/joystick.lua
@@ -55,7 +55,7 @@ ugui.registry.joystick = {
 
         return {
             primary = data.position,
-            meta = { signal_change = data.signal_change },
+            meta = {signal_change = data.signal_change},
         }
     end,
     ---@param control Joystick
@@ -66,8 +66,9 @@ ugui.registry.joystick = {
 
 ---Places a Joystick.
 ---@param control Joystick The control table.
+---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return Vector2, Meta
-ugui.joystick = function(control)
-    local result = ugui.control(control, 'joystick')
+ugui.joystick = function(control, fn)
+    local result = ugui.control(control, 'joystick', fn)
     return result.primary, result.meta
 end

--- a/src/ugui/controls/joystick.lua
+++ b/src/ugui/controls/joystick.lua
@@ -37,11 +37,11 @@ ugui.registry.joystick = {
 
         if ugui.internal.mouse_captured_control == control.uid then
             data.position.x = ugui.internal.clamp(
-                ugui.internal.remap(ugui.internal.environment.mouse_position.x - control.rectangle.x, 0,
-                    control.rectangle.width, -128, 128), -128, 128)
+                ugui.internal.remap(ugui.internal.environment.mouse_position.x - data.render_rect.x, 0,
+                    data.render_rect.width, -128, 128), -128, 128)
             data.position.y = ugui.internal.clamp(
-                ugui.internal.remap(ugui.internal.environment.mouse_position.y - control.rectangle.y, 0,
-                    control.rectangle.height, -128, 128), -128, 128)
+                ugui.internal.remap(ugui.internal.environment.mouse_position.y - data.render_rect.y, 0,
+                    data.render_rect.height, -128, 128), -128, 128)
             if control.x_snap and data.position.x > -control.x_snap and data.position.x < control.x_snap then
                 data.position.x = 0
             end

--- a/src/ugui/controls/label.lua
+++ b/src/ugui/controls/label.lua
@@ -42,6 +42,14 @@ ugui.registry.label = {
         local visual_state = ugui.get_visual_state(control)
         ugui.standard_styler.draw_rich_text(control.rectangle, control.align_x, control.align_y, control.text, control.color, visual_state, control.plaintext, control.font_name, control.font_size)
     end,
+    measure = function(node)
+        local control = node.control
+        ---@cast control Label
+
+        local font_name = control.font_name or ugui.standard_styler.params.font_name
+        local font_size = control.font_size or ugui.standard_styler.params.font_size
+        return ugui.standard_styler.compute_rich_text(control.text, control.plaintext, font_name, font_size).size
+    end,
 }
 
 ---Places a Label.

--- a/src/ugui/controls/label.lua
+++ b/src/ugui/controls/label.lua
@@ -39,8 +39,9 @@ ugui.registry.label = {
     end,
     ---@param control Label
     draw = function(control)
+        local render_rect = ugui.internal.control_data[control.uid].render_rect
         local visual_state = ugui.get_visual_state(control)
-        ugui.standard_styler.draw_rich_text(control.rectangle, control.align_x, control.align_y, control.text, control.color, visual_state, control.plaintext, control.font_name, control.font_size)
+        ugui.standard_styler.draw_rich_text(render_rect, control.align_x, control.align_y, control.text, control.color, visual_state, control.plaintext, control.font_name, control.font_size)
     end,
     measure = function(node)
         local control = node.control

--- a/src/ugui/controls/label.lua
+++ b/src/ugui/controls/label.lua
@@ -46,8 +46,9 @@ ugui.registry.label = {
 
 ---Places a Label.
 ---@param control Label The control table.
+---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return nil, Meta # Nothing.
-ugui.label = function(control)
-    local result = ugui.control(control, 'label')
+ugui.label = function(control, fn)
+    local result = ugui.control(control, 'label', fn)
     return result.primary, result.meta
 end

--- a/src/ugui/controls/listbox.lua
+++ b/src/ugui/controls/listbox.lua
@@ -183,8 +183,9 @@ ugui.registry.listbox = {
 
 ---Places a ListBox.
 ---@param control ListBox The control table.
+---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return integer, Meta # The new selected index.
-ugui.listbox = function(control)
+ugui.listbox = function(control, fn)
     local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
     local x_overflow = content_bounds.width > control.rectangle.width
     local y_overflow = content_bounds.height > control.rectangle.height
@@ -197,7 +198,7 @@ ugui.listbox = function(control)
         control.rectangle.width = control.rectangle.width - ugui.standard_styler.params.scrollbar.thickness
     end
 
-    local result = ugui.control(control, 'listbox')
+    local result = ugui.control(control, 'listbox', fn)
     local data = ugui.internal.control_data[control.uid]
 
     if x_overflow then

--- a/src/ugui/controls/listbox.lua
+++ b/src/ugui/controls/listbox.lua
@@ -146,9 +146,6 @@ ugui.registry.listbox = {
 
 
         data.scroll_y = ugui.internal.clamp(data.scroll_y, 0, 1)
-        if not y_overflow then
-            data.scroll_y = 0
-        end
         if data.selected_index ~= nil then
             data.selected_index = ugui.internal.clamp(data.selected_index, 1, #control.items)
         end

--- a/src/ugui/controls/listbox.lua
+++ b/src/ugui/controls/listbox.lua
@@ -37,20 +37,8 @@ ugui.registry.listbox = {
     logic = function(control, data)
         data.selected_index = control.selected_index
 
-        local prev_rect = ugui.internal.deep_clone(control.rectangle)
-        local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
-        local x_overflow = content_bounds.width > control.rectangle.width
-        local y_overflow = content_bounds.height > control.rectangle.height
-
-        if x_overflow then
-            control.rectangle.height = control.rectangle.height - ugui.standard_styler.params.scrollbar.thickness
-        end
-        if y_overflow then
-            control.rectangle.width = control.rectangle.width - ugui.standard_styler.params.scrollbar.thickness
-        end
-
         local one_item_scroll_y<const> = 1 / #control.items
-        local items_per_page<const> = math.floor(control.rectangle.height / ugui.standard_styler.params.listbox_item.height)
+        local items_per_page<const> = math.floor(data.render_rect.height / ugui.standard_styler.params.listbox_item.height)
 
         -- FIXME: This is pretty weird... we should have a mechanism at the ugui core level for this
         local can_mouse_scroll = false
@@ -63,7 +51,7 @@ ugui.registry.listbox = {
 
         local function index_from_y(y)
             return math.ceil((y + (data.scroll_y *
-                    ((ugui.standard_styler.params.listbox_item.height * #control.items) - control.rectangle.height))) /
+                    ((ugui.standard_styler.params.listbox_item.height * #control.items) - data.render_rect.height))) /
                 ugui.standard_styler.params.listbox_item.height)
         end
 
@@ -73,7 +61,7 @@ ugui.registry.listbox = {
             end
 
             local item_height = ugui.standard_styler.params.listbox_item.height
-            local scroll_range = (item_height * #control.items) - control.rectangle.height
+            local scroll_range = (item_height * #control.items) - data.render_rect.height
 
             if scroll_range <= 0 then
                 return
@@ -81,23 +69,23 @@ ugui.registry.listbox = {
 
             local scroll_offset_px = data.scroll_y * scroll_range
             local first_visible = math.floor(scroll_offset_px / item_height) + 1
-            local last_visible = math.floor((scroll_offset_px + control.rectangle.height) / item_height)
+            local last_visible = math.floor((scroll_offset_px + data.render_rect.height) / item_height)
 
             if data.selected_index < first_visible then
                 data.scroll_y = (data.selected_index - 1) * item_height / scroll_range
             elseif data.selected_index > last_visible then
-                data.scroll_y = (data.selected_index * item_height - control.rectangle.height) / scroll_range
+                data.scroll_y = (data.selected_index * item_height - data.render_rect.height) / scroll_range
             end
         end
 
         if ugui.internal.mouse_captured_control == control.uid then
-            local relative_y = ugui.internal.environment.mouse_position.y - control.rectangle.y
+            local relative_y = ugui.internal.environment.mouse_position.y - data.render_rect.y
             local new_index = index_from_y(relative_y)
             data.selected_index = new_index
 
             local overshoot = nil
-            if relative_y > control.rectangle.height then
-                overshoot = relative_y - control.rectangle.height
+            if relative_y > data.render_rect.height then
+                overshoot = relative_y - data.render_rect.height
             end
             if relative_y < 0 then
                 overshoot = relative_y
@@ -165,8 +153,6 @@ ugui.registry.listbox = {
             data.selected_index = ugui.internal.clamp(data.selected_index, 1, #control.items)
         end
 
-        control.rectangle = prev_rect
-
         data.signal_change = ugui.internal.process_signal_changes(data.signal_change,
             control.selected_index ~= data.selected_index)
 
@@ -179,6 +165,29 @@ ugui.registry.listbox = {
     draw = function(control)
         ugui.standard_styler.draw_listbox(control)
     end,
+    measure = function(node)
+        local control = node.control
+        ---@cast control ListBox
+
+        -- Since horizontal content bounds measuring is expensive, we only do this if explicitly enabled.
+        local max_width = 0
+        if control.horizontal_scroll == true then
+            for _, value in pairs(control.items) do
+                local size = ugui.standard_styler.compute_rich_text(value, control.plaintext, ugui.standard_styler.params.font_name, ugui.standard_styler.params.font_size).size
+
+                if size.x > max_width then
+                    max_width = size.x
+                end
+            end
+        else
+            max_width = 100
+        end
+
+        return {
+            x = max_width,
+            y = ugui.standard_styler.params.listbox_item.height * #control.items,
+        }
+    end,
 }
 
 ---Places a ListBox.
@@ -186,17 +195,17 @@ ugui.registry.listbox = {
 ---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return integer, Meta # The new selected index.
 ugui.listbox = function(control, fn)
-    local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
-    local x_overflow = content_bounds.width > control.rectangle.width
-    local y_overflow = content_bounds.height > control.rectangle.height
+    -- local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
+    -- local x_overflow = content_bounds.width > control.rectangle.width
+    -- local y_overflow = content_bounds.height > control.rectangle.height
 
     -- If we need scrollbars, we shrink the control rectangle to accomodate them.
-    if x_overflow then
-        control.rectangle.height = control.rectangle.height - ugui.standard_styler.params.scrollbar.thickness
-    end
-    if y_overflow then
-        control.rectangle.width = control.rectangle.width - ugui.standard_styler.params.scrollbar.thickness
-    end
+    -- if x_overflow then
+    --     control.rectangle.height = control.rectangle.height - ugui.standard_styler.params.scrollbar.thickness
+    -- end
+    -- if y_overflow then
+    --     control.rectangle.width = control.rectangle.width - ugui.standard_styler.params.scrollbar.thickness
+    -- end
 
     local result = ugui.control(control, 'listbox', fn)
     local data = ugui.internal.control_data[control.uid]

--- a/src/ugui/controls/listbox.lua
+++ b/src/ugui/controls/listbox.lua
@@ -195,49 +195,46 @@ ugui.registry.listbox = {
 ---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return integer, Meta # The new selected index.
 ugui.listbox = function(control, fn)
-    -- local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
-    -- local x_overflow = content_bounds.width > control.rectangle.width
-    -- local y_overflow = content_bounds.height > control.rectangle.height
+    local scrollbar_1_uid<const> = control.uid + 1
+    local scrollbar_2_uid<const> = control.uid + 2
 
-    -- If we need scrollbars, we shrink the control rectangle to accomodate them.
-    -- if x_overflow then
-    --     control.rectangle.height = control.rectangle.height - ugui.standard_styler.params.scrollbar.thickness
-    -- end
-    -- if y_overflow then
-    --     control.rectangle.width = control.rectangle.width - ugui.standard_styler.params.scrollbar.thickness
-    -- end
+    -- FIXME: We need to shrink the listbox to fit the scrollbars without overflowing.
+    -- Requires flex support so we're blocked by that lol...
 
     local result = ugui.control(control, 'listbox', fn)
     local data = ugui.internal.control_data[control.uid]
 
+    local x_overflow<const> = data.natural_size.x > data.render_rect.width
+    local y_overflow<const> = data.natural_size.y > data.render_rect.height
+
     if x_overflow then
         data.scroll_x = ugui.scrollbar({
-            uid = control.uid + 1,
+            uid = scrollbar_1_uid,
             is_enabled = control.is_enabled,
             rectangle = {
-                x = control.rectangle.x,
-                y = control.rectangle.y + control.rectangle.height,
-                width = control.rectangle.width,
+                x = data.render_rect.x,
+                y = data.render_rect.y + data.render_rect.height,
+                width = data.render_rect.width,
                 height = ugui.standard_styler.params.scrollbar.thickness,
             },
             value = data.scroll_x,
-            ratio = 1 / (content_bounds.width / control.rectangle.width),
+            ratio = 1 / (data.natural_size.x / data.render_rect.width),
             z_index = control.z_index,
         })
     end
 
     if y_overflow then
         data.scroll_y = ugui.scrollbar({
-            uid = control.uid + 2,
+            uid = scrollbar_2_uid,
             is_enabled = control.is_enabled,
             rectangle = {
-                x = control.rectangle.x + control.rectangle.width,
-                y = control.rectangle.y,
+                x = data.render_rect.x + data.render_rect.width,
+                y = data.render_rect.y,
                 width = ugui.standard_styler.params.scrollbar.thickness,
-                height = control.rectangle.height,
+                height = data.render_rect.height,
             },
             value = data.scroll_y,
-            ratio = 1 / (content_bounds.height / control.rectangle.height),
+            ratio = 1 / (data.natural_size.y / data.render_rect.height),
             z_index = control.z_index,
         })
     end

--- a/src/ugui/controls/listbox.lua
+++ b/src/ugui/controls/listbox.lua
@@ -204,6 +204,13 @@ ugui.listbox = function(control, fn)
     local x_overflow<const> = data.natural_size.x > data.render_rect.width
     local y_overflow<const> = data.natural_size.y > data.render_rect.height
 
+    if not x_overflow then
+        data.scroll_x = 0
+    end
+    if not y_overflow then
+        data.scroll_y = 0
+    end
+
     if x_overflow then
         data.scroll_x = ugui.scrollbar({
             uid = scrollbar_1_uid,

--- a/src/ugui/controls/menu.lua
+++ b/src/ugui/controls/menu.lua
@@ -27,45 +27,18 @@ ugui.registry.menu = {
     end,
     ---@param control Menu
     setup = function(control, data)
-        data.dismissed = 0
+        data.hovered_index = nil
+        data.dismissed_latch = false
     end,
     ---@param control Menu
     ---@return ControlReturnValue
     logic = function(control, data)
-        local function reset_hovered_index_for_all_child_menus(uid, items)
-            if ugui.internal.control_data[uid] then
-                ugui.internal.control_data[uid].hovered_index = nil
-            end
-            for _, item in pairs(items) do
-                if item.items then
-                    reset_hovered_index_for_all_child_menus(uid + 1, item.items)
-                end
-            end
-        end
-
         local result = {
             item = nil,
             dismissed = false,
         }
 
-        -- We want to delay returning the dismissed state by a frame because we don't get to handle inputs otherwise,
-        -- so we turn the dismissed flag into a tristate.
-        if data.dismissed == 2 then
-            data.dismissed = 0
-            result.dismissed = true
-        end
-
-        if data.dismissed == 1 then
-            data.dismissed = 2
-        end
-
-        if ugui.internal.is_mouse_just_down() and not BreitbandGraphics.is_point_inside_rectangle(ugui.internal.mouse_down_position, data.render_rect) then
-            data.dismissed = 1
-        end
-
         if ugui.internal.hovered_control == control.uid then
-            reset_hovered_index_for_all_child_menus(control.uid, control.items)
-
             local i = math.floor((ugui.internal.environment.mouse_position.y - data.render_rect.y) /
                 ugui.standard_styler.params.menu_item.height) + 1
             data.hovered_index = ugui.internal.clamp(i, 1, #control.items)
@@ -80,8 +53,8 @@ ugui.registry.menu = {
             end
         end
 
-        if result.dismissed or result.item then
-            reset_hovered_index_for_all_child_menus(control.uid, control.items)
+        if ugui.internal.is_mouse_just_down() and not BreitbandGraphics.is_point_inside_rectangle(ugui.internal.mouse_down_position, data.render_rect) then
+            result.dismissed = true
         end
 
         -- FIXME: Cursed flag... does this make sense?
@@ -98,6 +71,24 @@ ugui.registry.menu = {
         local data = ugui.internal.control_data[control.uid]
         ugui.standard_styler.draw_menu(control, data.render_rect)
     end,
+    measure = function(node)
+        local control = node.control
+        ---@cast control Menu
+
+        local max_text_width = 0
+        for _, item in pairs(control.items) do
+            local size = BreitbandGraphics.get_text_size(item.text, ugui.standard_styler.params.font_size,
+                ugui.standard_styler.params.font_name)
+            if size.width > max_text_width then
+                max_text_width = size.width
+            end
+        end
+
+        return {
+            x = max_text_width + ugui.standard_styler.params.menu_item.left_padding + ugui.standard_styler.params.menu_item.right_padding,
+            y = #control.items * ugui.standard_styler.params.menu_item.height,
+        }
+    end,
 }
 
 ---Places a Menu.
@@ -107,64 +98,61 @@ ugui.registry.menu = {
 ugui.menu = function(control, fn)
     control.z_index = control.z_index or 1000
 
-    -- We adjust the dimensions with what should fit the content
-    local max_text_width = 0
-    for _, item in pairs(control.items) do
-        local size = BreitbandGraphics.get_text_size(item.text, ugui.standard_styler.params.font_size,
-            ugui.standard_styler.params.font_name)
-        if size.width > max_text_width then
-            max_text_width = size.width
+    -- HACK: The old menu allowed width/height to be missing...
+    if control.rectangle then
+        control.margin = string.format('%fpx %fpx', control.rectangle.x, control.rectangle.y)
+        control.size = 'auto'
+        control.rectangle = nil
+    end
+
+    local results = {}
+    local function place_recursive(parent_menu)
+        local parent_data = ugui.internal.control_data[parent_menu.uid]
+
+        if not parent_data.hovered_index then
+            return
         end
-    end
 
-    control.rectangle.width = max_text_width + ugui.standard_styler.params.menu_item.left_padding +
-        ugui.standard_styler.params.menu_item.right_padding
-    control.rectangle.height = #control.items * ugui.standard_styler.params.menu_item.height
-
-    -- Overflow avoidance: shift the X/Y position to avoid going out of bounds
-    if control.rectangle.x + control.rectangle.width > ugui.internal.environment.window_size.x then
-        -- If the menu has a parent and there's an overflow on the X axis, try snaking out of the situation by moving left of the menu
-        if control.parent_rectangle then
-            control.rectangle.x = control.parent_rectangle.x - control.rectangle.width +
-                ugui.standard_styler.params.menu.overlap_size
-        else
-            control.rectangle.x = control.rectangle.x -
-                (control.rectangle.x + control.rectangle.width - ugui.internal.environment.window_size.x)
+        local item = parent_menu.items[parent_data.hovered_index]
+        if not item.items then
+            return
         end
-    end
-    if control.rectangle.y + control.rectangle.height > ugui.internal.environment.window_size.y then
-        control.rectangle.y = control.rectangle.y -
-            (control.rectangle.y + control.rectangle.height - ugui.internal.environment.window_size.y)
+
+        local menu = {
+            uid = parent_menu.uid + 1,
+            margin = string.format('%fpx %fpx', parent_data.render_rect.width - ugui.standard_styler.params.menu.overlap_size, (parent_data.hovered_index - 1) * ugui.standard_styler.params.menu_item.height),
+            items = item.items,
+            z_index = (parent_menu.z_index or 0) + 1,
+        }
+
+        table.insert(results, ugui.control(menu, 'menu', function()
+            place_recursive(menu)
+        end))
     end
 
-    local result = ugui.control(control, 'menu', fn)
+    table.insert(results, ugui.control(control, 'menu', function()
+        place_recursive(control)
+    end))
+
     local data = ugui.internal.control_data[control.uid]
 
-    -- Show child menu if there's any hovered one
-    if data.hovered_index ~= nil then
-        local i = data.hovered_index
-        local item = control.items[i]
-
-        if item.items and item.enabled ~= false then
-            local submenu_result = ugui.menu({
-                uid = control.uid + 1,
-                rectangle = {
-                    x = control.rectangle.x + control.rectangle.width - ugui.standard_styler.params.menu.overlap_size,
-                    y = control.rectangle.y + ((i - 1) * ugui.standard_styler.params.menu_item.height),
-                    width = 0,
-                    height = 0,
-                },
-                items = item.items,
-                z_index = (control.z_index or 0) + 1,
-                parent_rectangle = ugui.internal.deep_clone(control.rectangle),
-            })
-
-            if submenu_result.item then
-                result.dismissed = false
-                result.item = submenu_result.item
-            end
+    -- If any menu returned an item, we go with that
+    for _, result in pairs(results) do
+        if result.primary.item then
+            return {item = result.primary.item, dismissed = false}, {signal_change = ugui.signal_change_states.none}
         end
     end
 
-    return result, result.meta
+    -- Dismissals are queued up for one frame
+    for _, result in pairs(results) do
+        if result.primary.dismissed then
+            if data.dismissed_latch then
+                data.dismissed_latch = false
+                return {item = nil, dismissed = true}, {signal_change = ugui.signal_change_states.none}
+            end
+            data.dismissed_latch = true
+        end
+    end
+
+    return {item = nil, dismissed = false}, {signal_change = ugui.signal_change_states.none}
 end

--- a/src/ugui/controls/menu.lua
+++ b/src/ugui/controls/menu.lua
@@ -90,7 +90,7 @@ ugui.registry.menu = {
 
         return {
             primary = result,
-            meta = { signal_change = data.signal_change },
+            meta = {signal_change = data.signal_change},
         }
     end,
     ---@param control Menu
@@ -101,8 +101,9 @@ ugui.registry.menu = {
 
 ---Places a Menu.
 ---@param control Menu The control table.
+---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return MenuResult, Meta # The menu result.
-ugui.menu = function(control)
+ugui.menu = function(control, fn)
     control.z_index = control.z_index or 1000
 
     -- We adjust the dimensions with what should fit the content
@@ -135,7 +136,7 @@ ugui.menu = function(control)
             (control.rectangle.y + control.rectangle.height - ugui.internal.environment.window_size.y)
     end
 
-    local result = ugui.control(control, 'menu')
+    local result = ugui.control(control, 'menu', fn)
     local data = ugui.internal.control_data[control.uid]
 
     -- Show child menu if there's any hovered one

--- a/src/ugui/controls/menu.lua
+++ b/src/ugui/controls/menu.lua
@@ -59,14 +59,14 @@ ugui.registry.menu = {
             data.dismissed = 2
         end
 
-        if ugui.internal.is_mouse_just_down() and not BreitbandGraphics.is_point_inside_rectangle(ugui.internal.mouse_down_position, control.rectangle) then
+        if ugui.internal.is_mouse_just_down() and not BreitbandGraphics.is_point_inside_rectangle(ugui.internal.mouse_down_position, data.render_rect) then
             data.dismissed = 1
         end
 
         if ugui.internal.hovered_control == control.uid then
             reset_hovered_index_for_all_child_menus(control.uid, control.items)
 
-            local i = math.floor((ugui.internal.environment.mouse_position.y - control.rectangle.y) /
+            local i = math.floor((ugui.internal.environment.mouse_position.y - data.render_rect.y) /
                 ugui.standard_styler.params.menu_item.height) + 1
             data.hovered_index = ugui.internal.clamp(i, 1, #control.items)
         end
@@ -95,7 +95,8 @@ ugui.registry.menu = {
     end,
     ---@param control Menu
     draw = function(control)
-        ugui.standard_styler.draw_menu(control, control.rectangle)
+        local data = ugui.internal.control_data[control.uid]
+        ugui.standard_styler.draw_menu(control, data.render_rect)
     end,
 }
 

--- a/src/ugui/controls/numberbox.lua
+++ b/src/ugui/controls/numberbox.lua
@@ -45,7 +45,7 @@ ugui.registry.numberbox = {
                     font_size,
                     font_name).width
 
-                local left = control.rectangle.width / 2 - full_width / 2
+                local left = data.render_rect.width / 2 - full_width / 2
                 positions[#positions + 1] = width + left
             end
 
@@ -196,23 +196,23 @@ ugui.numberbox = function(control, fn)
     local data = ugui.internal.control_data[control.uid]
 
     if control.show_negative then
-        local negative_button_size = control.rectangle.width / 8
+        local negative_button_size = data.render_rect.width / 8
 
-        control.rectangle = {
-            x = control.rectangle.x + negative_button_size,
-            y = control.rectangle.y,
-            width = control.rectangle.width - negative_button_size,
-            height = control.rectangle.height,
+        data.render_rect = {
+            x = data.render_rect.x + negative_button_size,
+            y = data.render_rect.y,
+            width = data.render_rect.width - negative_button_size,
+            height = data.render_rect.height,
         }
 
         if ugui.button({
                 uid = control.uid + 1,
                 is_enabled = true,
                 rectangle = {
-                    x = control.rectangle.x - negative_button_size,
-                    y = control.rectangle.y,
+                    x = data.render_rect.x - negative_button_size,
+                    y = data.render_rect.y,
                     width = negative_button_size,
-                    height = control.rectangle.height,
+                    height = data.render_rect.height,
                 },
                 text = data.value >= 0 and '+' or '-',
             }) then

--- a/src/ugui/controls/numberbox.lua
+++ b/src/ugui/controls/numberbox.lua
@@ -64,7 +64,7 @@ ugui.registry.numberbox = {
 
         if ugui.internal.clicked_control == control.uid then
             data.caret_index = get_caret_index_at_relative_x(ugui.internal.environment.mouse_position.x -
-                control.rectangle.x)
+                data.render_rect.x)
         end
 
         if ugui.internal.keyboard_captured_control == control.uid then
@@ -142,11 +142,11 @@ ugui.registry.numberbox = {
         if ugui.internal.keyboard_captured_control == control.uid then
             visual_state = ugui.visual_states.active
         end
-        ugui.standard_styler.draw_edit_frame(control, control.rectangle, visual_state)
+        ugui.standard_styler.draw_edit_frame(data.render_rect, visual_state)
 
         BreitbandGraphics.draw_text2({
             text = text,
-            rectangle = control.rectangle,
+            rectangle = data.render_rect,
             color = ugui.standard_styler.params.textbox.text[visual_state],
             font_name = font_name,
             font_size = font_size,
@@ -162,13 +162,13 @@ ugui.registry.numberbox = {
             font_size,
             font_name).width
 
-        local left = control.rectangle.width / 2 - full_width / 2
+        local left = data.render_rect.width / 2 - full_width / 2
 
         local selected_char_rect = {
-            x = control.rectangle.x + left + text_width_up_to_caret,
-            y = control.rectangle.y,
+            x = data.render_rect.x + left + text_width_up_to_caret,
+            y = data.render_rect.y,
             width = font_size / 2,
-            height = control.rectangle.height,
+            height = data.render_rect.height,
         }
 
         if ugui.internal.keyboard_captured_control == control.uid then
@@ -176,7 +176,7 @@ ugui.registry.numberbox = {
             BreitbandGraphics.push_clip(selected_char_rect)
             BreitbandGraphics.draw_text2({
                 text = text,
-                rectangle = control.rectangle,
+                rectangle = data.render_rect,
                 color = BreitbandGraphics.invert_color(ugui.standard_styler.params.textbox.text[visual_state]),
                 font_name = font_name,
                 font_size = font_size,

--- a/src/ugui/controls/numberbox.lua
+++ b/src/ugui/controls/numberbox.lua
@@ -189,9 +189,10 @@ ugui.registry.numberbox = {
 
 ---Places a NumberBox.
 ---@param control NumberBox The control table.
+---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return integer, Meta # The new value.
-ugui.numberbox = function(control)
-    local _ = ugui.control(control, 'numberbox')
+ugui.numberbox = function(control, fn)
+    local _ = ugui.control(control, 'numberbox', fn)
     local data = ugui.internal.control_data[control.uid]
 
     if control.show_negative then

--- a/src/ugui/controls/panel.lua
+++ b/src/ugui/controls/panel.lua
@@ -1,0 +1,19 @@
+--
+-- Copyright (c) 2026, Mupen64 maintainers.
+--
+-- SPDX-License-Identifier: GPL-3.0-or-later
+--
+
+---@class Panel : Control
+---An inert control used mostly as a container for other controls.
+
+---@type ControlRegistryEntry
+ugui.registry.panel = {}
+
+---Places a Panel.
+---@param control Panel The control table.
+---@return nil, Meta # Nothing.
+ugui.panel = function(control)
+    local result = ugui.control(control, 'panel')
+    return result.primary, result.meta
+end

--- a/src/ugui/controls/panel.lua
+++ b/src/ugui/controls/panel.lua
@@ -12,8 +12,9 @@ ugui.registry.panel = {}
 
 ---Places a Panel.
 ---@param control Panel The control table.
+---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return nil, Meta # Nothing.
-ugui.panel = function(control)
-    local result = ugui.control(control, 'panel')
+ugui.panel = function(control, fn)
+    local result = ugui.control(control, 'panel', fn)
     return result.primary, result.meta
 end

--- a/src/ugui/controls/scrollbar.lua
+++ b/src/ugui/controls/scrollbar.lua
@@ -25,11 +25,11 @@ ugui.registry.scrollbar = {
     logic = function(control, data)
         data.value = control.value
 
-        local is_horizontal = control.rectangle.width > control.rectangle.height
+        local is_horizontal = data.render_rect.width > data.render_rect.height
 
         local thumb_size = is_horizontal
-            and control.rectangle.width * control.ratio
-            or control.rectangle.height * control.ratio
+            and data.render_rect.width * control.ratio
+            or data.render_rect.height * control.ratio
 
         if ugui.internal.mouse_captured_control == control.uid then
             local mouse_pos = ugui.internal.environment.mouse_position
@@ -37,16 +37,16 @@ ugui.registry.scrollbar = {
 
             if data.drag_offset == nil then
                 if is_horizontal then
-                    local thumb_start = ugui.internal.remap(data.value, 0, 1, 0, control.rectangle.width - thumb_size)
-                    data.drag_offset = mouse_down.x - (control.rectangle.x + thumb_start)
+                    local thumb_start = ugui.internal.remap(data.value, 0, 1, 0, data.render_rect.width - thumb_size)
+                    data.drag_offset = mouse_down.x - (data.render_rect.x + thumb_start)
                 else
-                    local thumb_start = ugui.internal.remap(data.value, 0, 1, 0, control.rectangle.height - thumb_size)
-                    data.drag_offset = mouse_down.y - (control.rectangle.y + thumb_start)
+                    local thumb_start = ugui.internal.remap(data.value, 0, 1, 0, data.render_rect.height - thumb_size)
+                    data.drag_offset = mouse_down.y - (data.render_rect.y + thumb_start)
                 end
             end
 
-            local current_pos = is_horizontal and (mouse_pos.x - control.rectangle.x - data.drag_offset) or (mouse_pos.y - control.rectangle.y - data.drag_offset)
-            local track_length = (is_horizontal and control.rectangle.width or control.rectangle.height) - thumb_size
+            local current_pos = is_horizontal and (mouse_pos.x - data.render_rect.x - data.drag_offset) or (mouse_pos.y - data.render_rect.y - data.drag_offset)
+            local track_length = (is_horizontal and data.render_rect.width or data.render_rect.height) - thumb_size
 
             data.value = ugui.internal.clamp(current_pos / track_length, 0, 1)
         else
@@ -63,27 +63,27 @@ ugui.registry.scrollbar = {
     ---@param control ScrollBar
     draw = function(control)
         local data = ugui.internal.control_data[control.uid]
-        local is_horizontal = control.rectangle.width > control.rectangle.height
+        local is_horizontal = data.render_rect.width > data.render_rect.height
 
         ---@type Rectangle
         local thumb_rectangle
 
         if is_horizontal then
-            local scrollbar_width = control.rectangle.width * control.ratio
-            local scrollbar_x = ugui.internal.remap(data.value, 0, 1, 0, control.rectangle.width - scrollbar_width)
+            local scrollbar_width = data.render_rect.width * control.ratio
+            local scrollbar_x = ugui.internal.remap(data.value, 0, 1, 0, data.render_rect.width - scrollbar_width)
             thumb_rectangle = {
-                x = control.rectangle.x + scrollbar_x,
-                y = control.rectangle.y,
+                x = data.render_rect.x + scrollbar_x,
+                y = data.render_rect.y,
                 width = scrollbar_width,
-                height = control.rectangle.height,
+                height = data.render_rect.height,
             }
         else
-            local scrollbar_height = control.rectangle.height * control.ratio
-            local scrollbar_y = ugui.internal.remap(data.value, 0, 1, 0, control.rectangle.height - scrollbar_height)
+            local scrollbar_height = data.render_rect.height * control.ratio
+            local scrollbar_y = ugui.internal.remap(data.value, 0, 1, 0, data.render_rect.height - scrollbar_height)
             thumb_rectangle = {
-                x = control.rectangle.x,
-                y = control.rectangle.y + scrollbar_y,
-                width = control.rectangle.width,
+                x = data.render_rect.x,
+                y = data.render_rect.y + scrollbar_y,
+                width = data.render_rect.width,
                 height = scrollbar_height,
             }
         end

--- a/src/ugui/controls/scrollbar.lua
+++ b/src/ugui/controls/scrollbar.lua
@@ -94,9 +94,10 @@ ugui.registry.scrollbar = {
 
 ---Places a ScrollBar.
 ---@param control ScrollBar The control table.
+---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return number, Meta # The new value.
-ugui.scrollbar = function(control)
-    local result = ugui.control(control, 'scrollbar')
+ugui.scrollbar = function(control, fn)
+    local result = ugui.control(control, 'scrollbar', fn)
     ---@cast result ControlReturnValue
     return result.primary, result.meta
 end

--- a/src/ugui/controls/spinner.lua
+++ b/src/ugui/controls/spinner.lua
@@ -46,10 +46,10 @@ ugui.spinner = function(control, fn)
     end
 
     local textbox_rect = {
-        x = control.rectangle.x,
-        y = control.rectangle.y,
-        width = control.rectangle.width - ugui.standard_styler.params.spinner.button_size * 2,
-        height = control.rectangle.height,
+        x = data.render_rect.x,
+        y = data.render_rect.y,
+        width = data.render_rect.width - ugui.standard_styler.params.spinner.button_size * 2,
+        height = data.render_rect.height,
     }
 
     local new_text = ugui.textbox({
@@ -78,11 +78,11 @@ ugui.spinner = function(control, fn)
                 uid = button_1_uid,
                 is_enabled = not (value == control.minimum_value),
                 rectangle = {
-                    x = control.rectangle.x + control.rectangle.width -
+                    x = data.render_rect.x + data.render_rect.width -
                         ugui.standard_styler.params.spinner.button_size * 2,
-                    y = control.rectangle.y,
+                    y = data.render_rect.y,
                     width = ugui.standard_styler.params.spinner.button_size,
-                    height = control.rectangle.height,
+                    height = data.render_rect.height,
                 },
                 text = '-',
             }))
@@ -94,11 +94,11 @@ ugui.spinner = function(control, fn)
                 uid = button_2_uid,
                 is_enabled = not (value == control.maximum_value),
                 rectangle = {
-                    x = control.rectangle.x + control.rectangle.width -
+                    x = data.render_rect.x + data.render_rect.width -
                         ugui.standard_styler.params.spinner.button_size,
-                    y = control.rectangle.y,
+                    y = data.render_rect.y,
                     width = ugui.standard_styler.params.spinner.button_size,
-                    height = control.rectangle.height,
+                    height = data.render_rect.height,
                 },
                 text = '+',
             }))
@@ -110,11 +110,11 @@ ugui.spinner = function(control, fn)
                 uid = button_3_uid,
                 is_enabled = not (value == control.maximum_value),
                 rectangle = {
-                    x = control.rectangle.x + control.rectangle.width -
+                    x = data.render_rect.x + data.render_rect.width -
                         ugui.standard_styler.params.spinner.button_size * 2,
-                    y = control.rectangle.y,
+                    y = data.render_rect.y,
                     width = ugui.standard_styler.params.spinner.button_size * 2,
-                    height = control.rectangle.height / 2,
+                    height = data.render_rect.height / 2,
                 },
                 text = '+',
             }))
@@ -126,11 +126,11 @@ ugui.spinner = function(control, fn)
                 uid = button_4_uid,
                 is_enabled = not (value == control.minimum_value),
                 rectangle = {
-                    x = control.rectangle.x + control.rectangle.width -
+                    x = data.render_rect.x + data.render_rect.width -
                         ugui.standard_styler.params.spinner.button_size * 2,
-                    y = control.rectangle.y + control.rectangle.height / 2,
+                    y = data.render_rect.y + data.render_rect.height / 2,
                     width = ugui.standard_styler.params.spinner.button_size * 2,
-                    height = control.rectangle.height / 2,
+                    height = data.render_rect.height / 2,
                 },
                 text = '-',
             }))

--- a/src/ugui/controls/spinner.lua
+++ b/src/ugui/controls/spinner.lua
@@ -17,6 +17,12 @@
 ---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return number, Meta # The new value.
 ugui.spinner = function(control, fn)
+    local textbox_uid<const> = control.uid + 1
+    local button_1_uid<const> = control.uid + 2
+    local button_2_uid<const> = control.uid + 4
+    local button_3_uid<const> = control.uid + 6
+    local button_4_uid<const> = control.uid + 8
+
     local _ = ugui.control(control, '', fn)
     local data = ugui.internal.control_data[control.uid]
 
@@ -47,7 +53,7 @@ ugui.spinner = function(control, fn)
     }
 
     local new_text = ugui.textbox({
-        uid = control.uid + 1,
+        uid = textbox_uid,
         rectangle = textbox_rect,
         text = tostring(value),
     })
@@ -69,7 +75,7 @@ ugui.spinner = function(control, fn)
 
     if control.is_horizontal then
         if (ugui.button({
-                uid = control.uid + 2,
+                uid = button_1_uid,
                 is_enabled = not (value == control.minimum_value),
                 rectangle = {
                     x = control.rectangle.x + control.rectangle.width -
@@ -85,7 +91,7 @@ ugui.spinner = function(control, fn)
         end
 
         if (ugui.button({
-                uid = control.uid + 3,
+                uid = button_2_uid,
                 is_enabled = not (value == control.maximum_value),
                 rectangle = {
                     x = control.rectangle.x + control.rectangle.width -
@@ -101,7 +107,7 @@ ugui.spinner = function(control, fn)
         end
     else
         if (ugui.button({
-                uid = control.uid + 2,
+                uid = button_3_uid,
                 is_enabled = not (value == control.maximum_value),
                 rectangle = {
                     x = control.rectangle.x + control.rectangle.width -
@@ -117,7 +123,7 @@ ugui.spinner = function(control, fn)
         end
 
         if (ugui.button({
-                uid = control.uid + 3,
+                uid = button_4_uid,
                 is_enabled = not (value == control.minimum_value),
                 rectangle = {
                     x = control.rectangle.x + control.rectangle.width -

--- a/src/ugui/controls/spinner.lua
+++ b/src/ugui/controls/spinner.lua
@@ -14,9 +14,10 @@
 
 ---Places a Spinner.
 ---@param control Spinner The control table.
+---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return number, Meta # The new value.
-ugui.spinner = function(control)
-    local _ = ugui.control(control, '')
+ugui.spinner = function(control, fn)
+    local _ = ugui.control(control, '', fn)
     local data = ugui.internal.control_data[control.uid]
 
     local increment = control.increment or 1
@@ -134,5 +135,5 @@ ugui.spinner = function(control)
 
     data.signal_change = ugui.internal.process_signal_changes(data.signal_change, control.value ~= value)
 
-    return clamp_value(value), { signal_change = data.signal_change }
+    return clamp_value(value), {signal_change = data.signal_change}
 end

--- a/src/ugui/controls/tabcontrol.lua
+++ b/src/ugui/controls/tabcontrol.lua
@@ -52,7 +52,7 @@ ugui.tabcontrol = function(control, fn)
         end
 
         local _, meta = ugui.toggle_button({
-            uid = control.uid + i,
+            uid = control.uid + i * 2,
             is_enabled = control.is_enabled,
             rectangle = {
                 x = control.rectangle.x + x,

--- a/src/ugui/controls/tabcontrol.lua
+++ b/src/ugui/controls/tabcontrol.lua
@@ -15,9 +15,10 @@
 
 ---Places a TabControl.
 ---@param control TabControl The control table.
+---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return TabControlResult, Meta # The result.
-ugui.tabcontrol = function(control)
-    local _ = ugui.control(control, '')
+ugui.tabcontrol = function(control, fn)
+    local _ = ugui.control(control, '', fn)
     local data = ugui.internal.control_data[control.uid]
 
     if data.scroll_x == nil then
@@ -81,5 +82,5 @@ ugui.tabcontrol = function(control)
             width = control.rectangle.width,
             height = control.rectangle.height - y - ugui.standard_styler.params.tabcontrol.rail_size,
         },
-    }, { signal_change = data.signal_change }
+    }, {signal_change = data.signal_change}
 end

--- a/src/ugui/controls/textbox.lua
+++ b/src/ugui/controls/textbox.lua
@@ -287,8 +287,9 @@ ugui.registry.textbox = {
 
 ---Places a TextBox.
 ---@param control TextBox The control table.
+---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return string, Meta # The new text.
-ugui.textbox = function(control)
-    local result = ugui.control(control, 'textbox')
+ugui.textbox = function(control, fn)
+    local result = ugui.control(control, 'textbox', fn)
     return result.primary, result.meta
 end

--- a/src/ugui/controls/textbox.lua
+++ b/src/ugui/controls/textbox.lua
@@ -78,7 +78,7 @@ ugui.registry.textbox = {
     logic = function(control, data)
         data.text = control.text
 
-        local index_at_mouse = ugui.internal.get_caret_index(data.text, data.scroll_offset, ugui.internal.environment.mouse_position.x - control.rectangle.x)
+        local index_at_mouse = ugui.internal.get_caret_index(data.text, data.scroll_offset, ugui.internal.environment.mouse_position.x - data.render_rect.x)
 
         -- If the control was just clicked, start a new selection or create/extend one with shift held.
         if ugui.internal.clicked_control == control.uid then
@@ -231,7 +231,7 @@ ugui.registry.textbox = {
         data.selection_end = ugui.internal.clamp(data.selection_end, 1, #data.text + 1)
 
         local padding_x = ugui.standard_styler.params.textbox.padding.x
-        local visible_width = control.rectangle.width - padding_x
+        local visible_width = data.render_rect.width - padding_x
 
         local function width_from_offset(offset, target_index)
             if target_index <= offset then

--- a/src/ugui/controls/toggle_button.lua
+++ b/src/ugui/controls/toggle_button.lua
@@ -46,6 +46,18 @@ ugui.registry.toggle_button = {
 ---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return boolean, Meta # The new check state.
 ugui.toggle_button = function(control, fn)
-    local result = ugui.control(control, 'toggle_button', fn)
+    local result = ugui.control(control, 'toggle_button', function()
+        local visual_state = ugui.get_visual_state(control)
+        ugui.label({
+            uid = control.uid + 1,
+            text = control.text,
+            x_align = 0.5,
+            y_align = 0.5,
+            color = ugui.standard_styler.params.button.text[visual_state],
+        })
+        if fn then
+            fn()
+        end
+    end)
     return result.primary, result.meta
 end

--- a/src/ugui/controls/toggle_button.lua
+++ b/src/ugui/controls/toggle_button.lua
@@ -51,7 +51,7 @@ ugui.toggle_button = function(control, fn)
         ugui.label({
             uid = control.uid + 1,
             text = control.text,
-            align = '50%',
+            align = '0.5',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
         if fn then

--- a/src/ugui/controls/toggle_button.lua
+++ b/src/ugui/controls/toggle_button.lua
@@ -51,8 +51,7 @@ ugui.toggle_button = function(control, fn)
         ugui.label({
             uid = control.uid + 1,
             text = control.text,
-            x_align = 0.5,
-            y_align = 0.5,
+            align = '50%',
             color = ugui.standard_styler.params.button.text[visual_state],
         })
         if fn then

--- a/src/ugui/controls/toggle_button.lua
+++ b/src/ugui/controls/toggle_button.lua
@@ -43,8 +43,9 @@ ugui.registry.toggle_button = {
 
 ---Places a ToggleButton.
 ---@param control ToggleButton The control table.
+---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return boolean, Meta # The new check state.
-ugui.toggle_button = function(control)
-    local result = ugui.control(control, 'toggle_button')
+ugui.toggle_button = function(control, fn)
+    local result = ugui.control(control, 'toggle_button', fn)
     return result.primary, result.meta
 end

--- a/src/ugui/controls/trackbar.lua
+++ b/src/ugui/controls/trackbar.lua
@@ -35,7 +35,7 @@ ugui.registry.trackbar = {
 
         return {
             primary = data.value,
-            meta = { signal_change = data.signal_change },
+            meta = {signal_change = data.signal_change},
         }
     end,
     ---@param control Trackbar
@@ -46,8 +46,9 @@ ugui.registry.trackbar = {
 
 ---Places a Trackbar.
 ---@param control Trackbar The control table.
+---@param fn fun()? The function to immediately invoke upon placing the control. In the function's context, any placed controls will be parented to this control.
 ---@return number, Meta # The trackbar's new value.
-ugui.trackbar = function(control)
-    local result = ugui.control(control, 'trackbar')
+ugui.trackbar = function(control, fn)
+    local result = ugui.control(control, 'trackbar', fn)
     return result.primary, result.meta
 end

--- a/src/ugui/controls/trackbar.lua
+++ b/src/ugui/controls/trackbar.lua
@@ -20,12 +20,12 @@ ugui.registry.trackbar = {
         data.value = control.value
 
         if ugui.internal.mouse_captured_control == control.uid then
-            if control.rectangle.width > control.rectangle.height then
-                data.value = (ugui.internal.environment.mouse_position.x - control.rectangle.x) / control.rectangle
+            if data.render_rect.width > data.render_rect.height then
+                data.value = (ugui.internal.environment.mouse_position.x - data.render_rect.x) / data.render_rect
                     .width
             else
-                data.value = (ugui.internal.environment.mouse_position.y - control.rectangle.y) /
-                    control.rectangle.height
+                data.value = (ugui.internal.environment.mouse_position.y - data.render_rect.y) /
+                    data.render_rect.height
             end
         end
 

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -17,7 +17,11 @@
 ---@class Control
 ---@field public hittestable boolean? Whether this control instance participates in hit-testing. Overrides the registry-level `hittestable` function if specified. Defaults to `true` if neither this nor the registry function is set.
 
----@alias SmartUnit string
+---@alias SmartUnit
+---| "0"
+---| "auto"
+---| string
+---
 ---A size unit specification that can be:
 ---
 ---    `"auto"` - natural size
@@ -38,7 +42,13 @@
 ---    `clamp(auto,5px,10px)`
 
 
----@alias SmartUnit2 string
+---@alias SmartUnit2
+---| "0"
+---| "auto"
+---| "0 0"
+---| "auto auto"
+---| string
+---
 ---A two-dimensional unit that is composed of two SmartUnits.
 ---
 ---If one component is omitted, it's assumed to be equal to the other component.
@@ -47,14 +57,50 @@
 ---    `100px` (expands to `100px 100px`)
 ---    `auto 50%`
 
----@alias SmartAlignment string
+---@alias SmartAlignment
+---| "0"
+---| "0%"
+---| "0.5"
+---| "50%"
+---| "1"
+---| "100%"
+---| "left"
+---| "right"
+---| "top"
+---| "bottom"
+---| "center"
+---| string
 ---An alignment unit that specifies how a control is aligned within its parent.
 ---
 ---    `0`, `0%` - start of parent
 ---    `0.5`, `50%` - center of parent
 ---    `1`, `100%` - end of parent
 
----@alias SmartAlignment2 string
+---@alias SmartAlignment2
+---| "0"
+---| "0 0"
+---| "0%"
+---| "0% 0%"
+---| "0.5"
+---| "0.5 0.5"
+---| "50%"
+---| "50% 50%"
+---| "1"
+---| "1 1"
+---| "100%"
+---| "100% 100%"
+---| "left"
+---| "left left"
+---| "right"
+---| "right right"
+---| "top"
+---| "top top"
+---| "bottom"
+---| "bottom bottom"
+---| "center"
+---| "center center"
+---| string
+---
 ---A two-dimensional alignment unit that is composed of two SmartAlignments.
 ---
 ---If one component is omitted, it's assumed to be equal to the other component.

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -16,6 +16,22 @@
 ---@class Control
 ---@field public hittestable boolean? Whether this control instance participates in hit-testing. Overrides the registry-level `hittestable` function if specified. Defaults to `true` if neither this nor the registry function is set.
 
+---@alias SmartUnit string
+---A size unit specification that can be:
+---
+---    `"auto"` - natural size (CURRENTLY UNSUPPORTED)
+---    `"{}px"` - absolute pixels (e.g. `"100px"`)
+---    `"{}%"` - percentage of parent size (e.g. `"50%"`) (CURRENTLY UNSUPPORTED)
+
+---@alias SmartUnit2 string
+---A two-dimensional unit specification that is composed of two SmartUnits.
+---
+---Examples:
+---
+---    `100px 100px`
+---    `100px` (expands to `100px 100px`)
+---    `auto auto`
+
 ---@alias UID number
 ---Unique identifier for a control. Must be unique within a frame.
 
@@ -244,6 +260,29 @@ ugui.control = function(control, type, fn)
 
     local revert_styler_mixin = ugui.internal.apply_styler_mixin(control)
 
+    ---@type SceneNode
+    local this_node = {
+        control = control,
+        type = type,
+        parent = ugui.internal.current_parent,
+        children = {},
+    }
+
+    if not control.rectangle then
+        control.rectangle = {x = 0, y = 0, width = 0, height = 0}
+    end
+    if control.margin then
+        local pos = ugui.internal.resolve_unit2(control.margin, this_node)
+        control.rectangle.x = pos.x
+        control.rectangle.y = pos.y
+    end
+    if control.size then
+        local size = ugui.internal.resolve_unit2(control.size, this_node)
+        control.rectangle.width = size.x
+        control.rectangle.height = size.y
+    end
+
+
     -- If the control has only just been added, we run its setup.
     if ugui.internal.control_data[control.uid] == nil then
         init_control_data(control.uid)
@@ -258,13 +297,8 @@ ugui.control = function(control, type, fn)
         end
     end
 
-    ---@type SceneNode
-    local this_node = {
-        control = control,
-        type = type,
-        parent = ugui.internal.current_parent,
-        children = {},
-    }
+
+
 
     if has_root then
         -- Check for UID duplicates.

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -26,20 +26,7 @@
 ---
 ---    `"auto"` - natural size
 ---    `"{}px"` - absolute pixels (e.g. `"100px"`)
----    `"{}%"` - percentage of parent size (e.g. `"50%"`)
----
----Zero literals are treated as `0px` (e.g. `0` => `0px`)
----
----Basic arithmetic operations are also supported: `+`, `-`, `*`, `/`.
----
----    `100px-3%`
----    `auto*10px`
----
----Constraints can also be applied:
----
----    `min(auto,5px)`
----    `max(auto,5px)`
----    `clamp(auto,5px,10px)`
+---    `"{}"` - fraction of parent size (e.g. `"0.5"`)
 
 
 ---@alias SmartUnit2
@@ -55,7 +42,7 @@
 ---
 ---    `100px 100px`
 ---    `100px` (expands to `100px 100px`)
----    `auto 50%`
+---    `auto 0.5`
 
 ---@alias SmartAlignment
 ---| "0"

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -303,6 +303,7 @@ ugui.control = function(control, type, fn)
     local function init_control_data(uid)
         ugui.internal.control_data[uid] = {
             signal_change = ugui.signal_change_states.none,
+            natural_size = {x = 0, y = 0},
             render_rect = {x = 0, y = 0, width = 0, height = 0},
         }
     end
@@ -326,7 +327,6 @@ ugui.control = function(control, type, fn)
     local this_node = {
         control = control,
         type = type,
-        natural_size = {x = 0, y = 0},
         parent = ugui.internal.current_parent,
         children = {},
     }

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -46,46 +46,22 @@
 
 ---@alias SmartAlignment
 ---| "0"
----| "0%"
 ---| "0.5"
----| "50%"
 ---| "1"
----| "100%"
----| "left"
----| "right"
----| "top"
----| "bottom"
----| "center"
 ---| string
 ---An alignment unit that specifies how a control is aligned within its parent.
 ---
----    `0`, `0%` - start of parent
----    `0.5`, `50%` - center of parent
----    `1`, `100%` - end of parent
+---    `0` - start of parent
+---    `0.5` - center of parent
+---    `1` - end of parent
 
 ---@alias SmartAlignment2
 ---| "0"
 ---| "0 0"
----| "0%"
----| "0% 0%"
 ---| "0.5"
 ---| "0.5 0.5"
----| "50%"
----| "50% 50%"
 ---| "1"
 ---| "1 1"
----| "100%"
----| "100% 100%"
----| "left"
----| "left left"
----| "right"
----| "right right"
----| "top"
----| "top top"
----| "bottom"
----| "bottom bottom"
----| "center"
----| "center center"
 ---| string
 ---
 ---A two-dimensional alignment unit that is composed of two SmartAlignments.
@@ -94,11 +70,8 @@
 ---
 ---    `0 0` - top-left corner
 ---    `0` - top-left corner
----    `50%`, `center`, `center center` - center
----    `left`, `left left` - left edge
----    `right`, `right right` - right edge
----    `top`, `top top` - top edge
----    `bottom`, `bottom bottom` - bottom edge
+---    `0.5`, `0.5 0.5` - center
+---    `1 1` - bottom-right corner
 
 ---@alias UID number
 ---Unique identifier for a control. Must be unique within a frame.

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -39,13 +39,33 @@
 
 
 ---@alias SmartUnit2 string
----A two-dimensional unit specification that is composed of two SmartUnits.
+---A two-dimensional unit that is composed of two SmartUnits.
 ---
----Examples:
+---If one component is omitted, it's assumed to be equal to the other component.
 ---
 ---    `100px 100px`
 ---    `100px` (expands to `100px 100px`)
----    `auto auto`
+---    `auto 50%`
+
+---@alias SmartAlignment string
+---An alignment unit that specifies how a control is aligned within its parent.
+---
+---    `0`, `0%` - start of parent
+---    `0.5`, `50%` - center of parent
+---    `1`, `100%` - end of parent
+
+---@alias SmartAlignment2 string
+---A two-dimensional alignment unit that is composed of two SmartAlignments.
+---
+---If one component is omitted, it's assumed to be equal to the other component.
+---
+---    `0 0` - top-left corner
+---    `0` - top-left corner
+---    `50%`, `center`, `center center` - center
+---    `left`, `left left` - left edge
+---    `right`, `right right` - right edge
+---    `top`, `top top` - top edge
+---    `bottom`, `bottom bottom` - bottom edge
 
 ---@alias UID number
 ---Unique identifier for a control. Must be unique within a frame.

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -21,7 +21,7 @@
 ---
 ---    `"auto"` - natural size (CURRENTLY UNSUPPORTED)
 ---    `"{}px"` - absolute pixels (e.g. `"100px"`)
----    `"{}%"` - percentage of parent size (e.g. `"50%"`) (CURRENTLY UNSUPPORTED)
+---    `"{}%"` - percentage of parent size (e.g. `"50%"`)
 
 ---@alias SmartUnit2 string
 ---A two-dimensional unit specification that is composed of two SmartUnits.

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -303,6 +303,7 @@ ugui.control = function(control, type, fn)
     local function init_control_data(uid)
         ugui.internal.control_data[uid] = {
             signal_change = ugui.signal_change_states.none,
+            render_rect = {x = 0, y = 0, width = 0, height = 0},
         }
     end
 
@@ -380,15 +381,15 @@ ugui.control = function(control, type, fn)
         registry_entry.validate(control)
     end
 
-    -- Run logic pass immediately for the current frame so callers receive an up-to-date value instead of the previous frame's result.
-    if registry_entry.logic then
-        return_value = registry_entry.logic(control, ugui.internal.control_data[control.uid])
-    end
-
     if has_root then
         ugui.internal.current_parent.children[#ugui.internal.current_parent.children + 1] = this_node
     end
     ugui.internal.control_types[control.uid] = type
+
+    -- Run logic pass immediately for the current frame so callers receive an up-to-date value instead of the previous frame's result.
+    if registry_entry.logic then
+        return_value = registry_entry.logic(control, ugui.internal.control_data[control.uid])
+    end
 
     revert_styler_mixin()
 

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -22,6 +22,18 @@
 ---    `"auto"` - natural size (CURRENTLY UNSUPPORTED)
 ---    `"{}px"` - absolute pixels (e.g. `"100px"`)
 ---    `"{}%"` - percentage of parent size (e.g. `"50%"`)
+---
+---Basic arithmetic operations are also supported: `+`, `-`, `*`, `/`.
+---
+---    `100px-3%`
+---    `auto*10px`
+---
+---Constraints can also be applied:
+---
+---    `min(auto, 5px)`
+---    `max(auto, 5px)`
+---    `clamp(auto, 5px, 10px)`
+
 
 ---@alias SmartUnit2 string
 ---A two-dimensional unit specification that is composed of two SmartUnits.

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -19,7 +19,7 @@
 ---@alias SmartUnit string
 ---A size unit specification that can be:
 ---
----    `"auto"` - natural size (CURRENTLY UNSUPPORTED)
+---    `"auto"` - natural size (CURRENTLY UNSUPPORTED TODO: SUPPORT THIS ASAP, NEEDED FOR EVERY CONTROL!!!)
 ---    `"{}px"` - absolute pixels (e.g. `"100px"`)
 ---    `"{}%"` - percentage of parent size (e.g. `"50%"`)
 ---

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -193,7 +193,7 @@ ugui.end_frame = function()
         end
     end)
 
-    -- ugui.internal.tooltip()
+    ugui.internal.tooltip()
 
     -- Store UIDs that were present in this frame
     ugui.internal.previous_uids = {}

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -10,6 +10,7 @@
 ---@field public added fun(control: Control, data: any)? Notifies about a control being added to a scene.
 ---@field public logic (fun(control: Control, data: any): ControlReturnValue)? Executes control logic.
 ---@field public draw (fun(control: Control))? Draws the control.
+---@field public measure (fun(node: SceneNode): Vector2)? Measures the control's natural size.
 ---@field public hittestable (fun(control: Control): boolean)? A function returning whether a control instance of this type should participate in hit-testing. If `nil`, the instance-level `hittestable` field is used. If both are `nil`, the control is hittestable.
 ---Represents an entry in the control registry.
 
@@ -202,27 +203,7 @@ ugui.end_frame = function()
     ugui.internal.dispatch_events()
 
     -- 5. Rendering pass
-    ugui.internal.foreach_node_from_root(function(node)
-        local control = node.control
-        local type = node.type
-
-        local entry = ugui.registry[type]
-
-        if entry.draw then
-            local revert_styler_mixin = ugui.internal.apply_styler_mixin(control)
-            entry.draw(control)
-            revert_styler_mixin()
-        end
-
-        if ugui.DEBUG then
-            if ugui.internal.keyboard_captured_control == control.uid then
-                BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle(control.rectangle, 4), '#000000', 2)
-            end
-            if ugui.internal.mouse_captured_control == control.uid then
-                BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle(control.rectangle, 8), '#FF0000', 2)
-            end
-        end
-    end)
+    ugui.internal.render()
 
     ugui.internal.tooltip()
 
@@ -276,6 +257,7 @@ ugui.control = function(control, type, fn)
     local this_node = {
         control = control,
         type = type,
+        natural_size = {x = 0, y = 0},
         parent = ugui.internal.current_parent,
         children = {},
     }
@@ -292,18 +274,9 @@ ugui.control = function(control, type, fn)
 
     if not control.rectangle then
         control.rectangle = {x = 0, y = 0, width = 0, height = 0}
+        control.margin = control.margin or '0px'
+        control.size = control.size or 'auto'
     end
-    if control.margin then
-        local pos = ugui.internal.resolve_unit2(control.margin, this_node)
-        control.rectangle.x = pos.x
-        control.rectangle.y = pos.y
-    end
-    if control.size then
-        local size = ugui.internal.resolve_unit2(control.size, this_node)
-        control.rectangle.width = size.x
-        control.rectangle.height = size.y
-    end
-
 
     -- If the control has only just been added, we run its setup.
     if ugui.internal.control_data[control.uid] == nil then

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -268,6 +268,16 @@ ugui.control = function(control, type, fn)
         children = {},
     }
 
+    -- Disable the control if any parent is disabled.
+    local node = ugui.internal.current_parent
+    while node do
+        if node.control.is_enabled == false then
+            control.is_enabled = false
+            break
+        end
+        node = node.parent
+    end
+
     if not control.rectangle then
         control.rectangle = {x = 0, y = 0, width = 0, height = 0}
     end
@@ -296,9 +306,6 @@ ugui.control = function(control, type, fn)
             return_value = registry_entry.logic(control, ugui.internal.control_data[control.uid])
         end
     end
-
-
-
 
     if has_root then
         -- Check for UID duplicates.

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -20,9 +20,11 @@
 ---@alias SmartUnit string
 ---A size unit specification that can be:
 ---
----    `"auto"` - natural size (CURRENTLY UNSUPPORTED TODO: SUPPORT THIS ASAP, NEEDED FOR EVERY CONTROL!!!)
+---    `"auto"` - natural size
 ---    `"{}px"` - absolute pixels (e.g. `"100px"`)
 ---    `"{}%"` - percentage of parent size (e.g. `"50%"`)
+---
+---Zero literals are treated as `0px` (e.g. `0` => `0px`)
 ---
 ---Basic arithmetic operations are also supported: `+`, `-`, `*`, `/`.
 ---

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -30,9 +30,9 @@
 ---
 ---Constraints can also be applied:
 ---
----    `min(auto, 5px)`
----    `max(auto, 5px)`
----    `clamp(auto, 5px, 10px)`
+---    `min(auto,5px)`
+---    `max(auto,5px)`
+---    `clamp(auto,5px,10px)`
 
 
 ---@alias SmartUnit2 string

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -232,6 +232,7 @@ ugui.begin_frame = function(environment)
     end
 
     ugui.internal.root = nil
+    ugui.internal.current_parent = nil
     ugui.panel({
         uid = 0,
         rectangle = {x = 0, y = 0, width = ugui.internal.environment.window_size.x, height = ugui.internal.environment.window_size.y},

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -5,11 +5,11 @@
 --
 
 ---@class ControlRegistryEntry
----@field public validate fun(control: Control) Verifies that a control instance matches the desired type.
+---@field public validate fun(control: Control)? Verifies that a control instance matches the desired type.
 ---@field public setup fun(control: Control, data: any)? Sets up the initial control data to be used in `logic` and `draw`.
 ---@field public added fun(control: Control, data: any)? Notifies about a control being added to a scene.
----@field public logic fun(control: Control, data: any): ControlReturnValue Executes control logic.
----@field public draw fun(control: Control) Draws the control.
+---@field public logic (fun(control: Control, data: any): ControlReturnValue)? Executes control logic.
+---@field public draw (fun(control: Control))? Draws the control.
 ---@field public hittestable (fun(control: Control): boolean)? A function returning whether a control instance of this type should participate in hit-testing. If `nil`, the instance-level `hittestable` field is used. If both are `nil`, the control is hittestable.
 ---Represents an entry in the control registry.
 
@@ -43,7 +43,7 @@
 
 ---@alias ControlReturnValue { primary: any, meta: Meta }
 
----@alias ControlType "label" | "button" | "toggle_button" | "carrousel_button" | "textbox" | "joystick" | "trackbar" | "listbox" | "scrollbar" | "combobox" | "menu" | "numberbox"
+---@alias ControlType "panel" | "label" | "button" | "toggle_button" | "carrousel_button" | "textbox" | "joystick" | "trackbar" | "listbox" | "scrollbar" | "combobox" | "menu" | "numberbox"
 
 ---@enum VisualState
 -- The possible states of a control, which are used by the styler for drawing.
@@ -146,6 +146,12 @@ ugui.begin_frame = function(environment)
     if ugui.internal.is_mouse_just_down() then
         ugui.internal.mouse_down_position = ugui.internal.environment.mouse_position
     end
+
+    ugui.internal.root = nil
+    ugui.panel({
+        uid = 0,
+        rectangle = {x = 0, y = 0, width = ugui.internal.environment.window_size.x, height = ugui.internal.environment.window_size.y},
+    })
 end
 
 --- Ends the current frame.
@@ -165,17 +171,17 @@ ugui.end_frame = function()
     ugui.internal.dispatch_events()
 
     -- 4. Rendering pass
-    for i = 1, #ugui.internal.scene, 1 do
-        local control = ugui.internal.scene[i].control
-        local type = ugui.internal.scene[i].type
+    ugui.internal.foreach_node_from_root(function(node)
+        local control = node.control
+        local type = node.type
 
         local entry = ugui.registry[type]
 
-        local revert_styler_mixin = ugui.internal.apply_styler_mixin(control)
-
-        entry.draw(control)
-
-        revert_styler_mixin()
+        if entry.draw then
+            local revert_styler_mixin = ugui.internal.apply_styler_mixin(control)
+            entry.draw(control)
+            revert_styler_mixin()
+        end
 
         if ugui.DEBUG then
             if ugui.internal.keyboard_captured_control == control.uid then
@@ -185,18 +191,17 @@ ugui.end_frame = function()
                 BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle(control.rectangle, 8), '#FF0000', 2)
             end
         end
-    end
+    end)
 
-    ugui.internal.tooltip()
+    -- ugui.internal.tooltip()
 
     -- Store UIDs that were present in this frame
     ugui.internal.previous_uids = {}
-    for i = 1, #ugui.internal.scene, 1 do
-        local control = ugui.internal.scene[i].control
+    for i = 1, #ugui.internal.root, 1 do
+        local control = ugui.internal.root[i].control
         ugui.internal.previous_uids[control.uid] = true
     end
 
-    ugui.internal.scene = {}
     ugui.internal.last_control_rectangle = nil
     ugui.internal.frame_in_progress = false
 end
@@ -216,16 +221,14 @@ ugui.control = function(control, type)
         init_control_data(control.uid)
         return nil
     end
+
     ---@cast type ControlType
 
-    ---@type ControlRegistryEntry?
     local registry_entry = ugui.registry[type]
+    ugui.internal.assert(registry_entry ~= nil, string.format("Unknown control type '%s'", type))
 
-    if registry_entry == nil then
-        error(string.format("Unknown control type '%s'", type))
-    end
-
-    local return_value
+    local return_value = {primary = nil, meta = {signal_change = ugui.signal_change_states.none}}
+    local has_root<const> = ugui.internal.root ~= nil
 
     local revert_styler_mixin = ugui.internal.apply_styler_mixin(control)
 
@@ -237,36 +240,47 @@ ugui.control = function(control, type)
             registry_entry.setup(control, ugui.internal.control_data[control.uid])
         end
 
-        -- Run logic once to stabilize the return value for the first state
-        return_value = registry_entry.logic(control, ugui.internal.control_data[control.uid])
-    end
-
-    -- Check for UID duplicates
-    for i = 1, #ugui.internal.scene, 1 do
-        local uid = ugui.internal.scene[i].control.uid
-        if control.uid == uid then
-            error(string.format(
-                'Attempted to show a control with uid %d, which is already in use! Note that some controls reserve more than one uid slot after them.',
-                control.uid))
+        -- Run logic once to stabilize the return value for the first state.
+        if registry_entry.logic then
+            return_value = registry_entry.logic(control, ugui.internal.control_data[control.uid])
         end
     end
 
-    -- Check that any existing control with the same UID matches this control's type
-    local stored_control_type = ugui.internal.control_types[control.uid]
-    if stored_control_type ~= nil and stored_control_type ~= type then
-        error(string.format('Attempted to reuse UID %d of %s for %s.', control.uid,
-            ugui.internal.control_types[control.uid], type))
+    if has_root then
+        -- Check for UID duplicates.
+        ugui.internal.foreach_node_from_root(function(node)
+            local uid = node.control.uid
+            ugui.internal.assert(control.uid ~= uid, string.format('Attempted to show a control with uid %d, which is already in use! Note that some controls reserve more than one uid slot after them.', uid))
+        end)
+
+        -- Check for cross-frame control type clobbering (e.g. button becoming a textbox)
+        local stored_control_type = ugui.internal.control_types[control.uid]
+        ugui.internal.assert(stored_control_type == nil or stored_control_type == type,
+            string.format('Attempted to reuse UID %d of %s for %s.', control.uid, stored_control_type, type))
+    else
+        ugui.internal.root = {
+            control = control,
+            type = type,
+            children = {},
+        }
     end
 
-    registry_entry.validate(control)
+    if registry_entry.validate then
+        registry_entry.validate(control)
+    end
 
     -- Run logic pass immediately for the current frame so callers receive an up-to-date value instead of the previous frame's result.
-    return_value = registry_entry.logic(control, ugui.internal.control_data[control.uid])
+    if registry_entry.logic then
+        return_value = registry_entry.logic(control, ugui.internal.control_data[control.uid])
+    end
 
-    ugui.internal.scene[#ugui.internal.scene + 1] = {
-        control = control,
-        type = type,
-    }
+    if has_root then
+        ugui.internal.root.children[#ugui.internal.root.children + 1] = {
+            control = control,
+            type = type,
+            children = {},
+        }
+    end
     ugui.internal.control_types[control.uid] = type
 
     revert_styler_mixin()

--- a/src/ugui/core.lua
+++ b/src/ugui/core.lua
@@ -164,13 +164,16 @@ ugui.end_frame = function()
     -- 1. Z-Sorting pass
     ugui.internal.sort_scene()
 
-    -- 2. Input processing pass
+    -- 2. Layout pass
+    ugui.internal.layout()
+
+    -- 3. Input processing pass
     ugui.internal.do_input_processing()
 
-    -- 3. Event dispatching pass
+    -- 4. Event dispatching pass
     ugui.internal.dispatch_events()
 
-    -- 4. Rendering pass
+    -- 5. Rendering pass
     ugui.internal.foreach_node_from_root(function(node)
         local control = node.control
         local type = node.type
@@ -195,6 +198,14 @@ ugui.end_frame = function()
 
     ugui.internal.tooltip()
 
+    if ugui.DEBUG then
+        for _, e in pairs(ugui.internal.environment.key_events) do
+            if e.pressed and e.keycode == ugui.keycodes.VK_A then
+                ugui.internal.print_tree(ugui.internal.root)
+            end
+        end
+    end
+
     -- Store UIDs that were present in this frame
     ugui.internal.previous_uids = {}
     for i = 1, #ugui.internal.root, 1 do
@@ -209,8 +220,9 @@ end
 ---Places a Control of the specified type.
 ---@param control Control The control.
 ---@param type ControlType | "" The control's type. If the type is `""`, no control will be placed, but the control data entry will be initialized.
+---@param fn fun()? The function to immediately invoke upon placing the button. In the function's context, any placed controls will be parented to this control.
 ---@return ControlReturnValue # The control's return value, or `nil` if the type is `""`.
-ugui.control = function(control, type)
+ugui.control = function(control, type, fn)
     local function init_control_data(uid)
         ugui.internal.control_data[uid] = {
             signal_change = ugui.signal_change_states.none,
@@ -246,6 +258,14 @@ ugui.control = function(control, type)
         end
     end
 
+    ---@type SceneNode
+    local this_node = {
+        control = control,
+        type = type,
+        parent = ugui.internal.current_parent,
+        children = {},
+    }
+
     if has_root then
         -- Check for UID duplicates.
         ugui.internal.foreach_node_from_root(function(node)
@@ -258,11 +278,8 @@ ugui.control = function(control, type)
         ugui.internal.assert(stored_control_type == nil or stored_control_type == type,
             string.format('Attempted to reuse UID %d of %s for %s.', control.uid, stored_control_type, type))
     else
-        ugui.internal.root = {
-            control = control,
-            type = type,
-            children = {},
-        }
+        ugui.internal.root = this_node
+        ugui.internal.current_parent = this_node
     end
 
     if registry_entry.validate then
@@ -275,15 +292,18 @@ ugui.control = function(control, type)
     end
 
     if has_root then
-        ugui.internal.root.children[#ugui.internal.root.children + 1] = {
-            control = control,
-            type = type,
-            children = {},
-        }
+        ugui.internal.current_parent.children[#ugui.internal.current_parent.children + 1] = this_node
     end
     ugui.internal.control_types[control.uid] = type
 
     revert_styler_mixin()
+
+    if fn then
+        local prev_parent = ugui.internal.current_parent
+        ugui.internal.current_parent = this_node
+        fn()
+        ugui.internal.current_parent = prev_parent
+    end
 
     return return_value
 end

--- a/src/ugui/helpers.lua
+++ b/src/ugui/helpers.lua
@@ -326,16 +326,30 @@ ugui.internal.print_tree = function(node)
     print('')
 end
 
-
 ---Resolves a SmartUnit2 to a Vector2.
 ---@param unit SmartUnit2
 ---@param node SceneNode
 ---@return Vector2
 ugui.internal.resolve_unit2 = function(unit, node)
-    local function resolve_unit(unit)
+    local function resolve_unit(unit, axis)
         local px = unit:match('^([%-%d%.]+)px$')
-        ugui.internal.assert(px, string.format('unsupported SmartUnit: %q', unit))
-        return tonumber(px)
+
+        if px then
+            return tonumber(px)
+        end
+
+        local percent = unit:match('^([%-%d%.]+)%%$')
+
+        if percent then
+            ugui.internal.assert(node.parent, 'percentage unit requires parent node')
+
+            local parent_rc = node.parent.control.rectangle
+            local basis = axis == 'x' and parent_rc.width or parent_rc.height
+
+            return basis * (tonumber(percent) / 100)
+        end
+
+        ugui.internal.assert(false, string.format('unsupported SmartUnit: %q', unit))
     end
 
     local a, b = unit:match('^(%S+)%s+(%S+)$')
@@ -346,7 +360,7 @@ ugui.internal.resolve_unit2 = function(unit, node)
     end
 
     return {
-        x = resolve_unit(a),
-        y = resolve_unit(b),
+        x = resolve_unit(a, 'x'),
+        y = resolve_unit(b, 'y'),
     }
 end

--- a/src/ugui/helpers.lua
+++ b/src/ugui/helpers.lua
@@ -72,7 +72,6 @@ ugui.internal.stable_sort = function(t, cmp)
     local function merge(left, right)
         local result = {}
         local i, j = 1, 1
-
         while i <= #left and j <= #right do
             -- If left < right, or they are "equal" (cmp false both ways),
             -- take from the left to preserve stability
@@ -84,7 +83,6 @@ ugui.internal.stable_sort = function(t, cmp)
                 j = j + 1
             end
         end
-
         while i <= #left do
             table.insert(result, left[i])
             i = i + 1
@@ -93,16 +91,21 @@ ugui.internal.stable_sort = function(t, cmp)
             table.insert(result, right[j])
             j = j + 1
         end
-
         return result
     end
 
     local function mergesort(arr)
-        if #arr <= 1 then return arr end
+        if #arr <= 1 then
+            return arr
+        end
         local mid = math.floor(#arr / 2)
         local left, right = {}, {}
-        for i = 1, mid do table.insert(left, arr[i]) end
-        for i = mid + 1, #arr do table.insert(right, arr[i]) end
+        for i = 1, mid do
+            table.insert(left, arr[i])
+        end
+        for i = mid + 1, #arr do
+            table.insert(right, arr[i])
+        end
         return merge(mergesort(left), mergesort(right))
     end
 
@@ -208,4 +211,59 @@ end
 ---@return number # The new limited value.
 ugui.internal.clamp = function(value, min, max)
     return math.max(math.min(value, max), min)
+end
+
+---Traverses a tree node depth-first and invokes a callback function for each node.
+---@param node table The node to traverse.
+---@param callback fun(node: SceneNode): boolean? The callback function to invoke for each node. If the callback returns `false`, the traversal is stopped early.
+ugui.internal.foreach_node = function(node, callback)
+    if callback(node) == false then
+        return
+    end
+    for _, child in ipairs(node.children) do
+        if ugui.internal.foreach_node(child, callback) == false then
+            return
+        end
+    end
+end
+
+---Traverses the scene depth-first from the root downwards.
+---@param callback fun(node: SceneNode): boolean? The callback function to invoke for each node. If the callback returns `false`, the traversal is stopped early.
+ugui.internal.foreach_node_from_root = function(callback)
+    ugui.internal.foreach_node(ugui.internal.root, callback)
+end
+
+
+---Recursively sorts a scene tree by Z-index, maintaining stable sort order.
+---@param node SceneNode
+ugui.internal.sort_scene_tree = function(node)
+    -- First, recursively sort all children
+    for _, child in ipairs(node.children) do
+        ugui.internal.sort_scene_tree(child)
+    end
+
+    -- Then sort this node's children by Z-index
+    ugui.internal.stable_sort(node.children, function(a, b)
+        return (a.control.z_index or 0) < (b.control.z_index or 0)
+    end)
+end
+
+---Sorts controls in the scene tree by their Z-index.
+ugui.internal.sort_scene = function()
+    ugui.internal.sort_scene_tree(ugui.internal.root)
+end
+
+---Returns the control at the given point, if any.
+---@param pt Vector2 The point to check for a control.
+---@return Control? The control at the given point, or `nil` if no control is found.
+ugui.internal.control_from_point = function(pt)
+    local result = nil
+    ugui.internal.foreach_node_from_root(function(node)
+        local control = node.control
+        if ugui.internal.is_point_inside_control(pt, control) then
+            result = control
+            return false
+        end
+    end)
+    return result
 end

--- a/src/ugui/helpers.lua
+++ b/src/ugui/helpers.lua
@@ -328,35 +328,32 @@ end
 
 ---Parses and resolves a SmartUnit.
 ---@param expr string
----@param node SceneNode
 ---@param axis '"x"'|'"y"'
+---@param parent_size number?
+---@param natural_basis number?
 ---@return number
-local function resolve_unit(expr, node, axis)
-    local parent = node.parent and node.parent.control.rectangle
+local function resolve_unit(expr, axis, parent_size, natural_basis)
+    local function get_parent_basis()
+        local basis = parent_size
+        ugui.internal.assert(basis ~= nil, 'fractional unit requires parent basis')
+        ---@cast basis number
 
-    local function parent_basis()
-        ugui.internal.assert(parent, 'fractional unit requires parent node')
-
-        return axis == 'x'
-            and parent.width
-            or parent.height
+        return basis
     end
 
-    local function natural_basis()
-        local natural = ugui.internal.control_data[node.control.uid].natural_size
+    local function get_natural_basis()
+        local basis = natural_basis
+        ugui.internal.assert(basis ~= nil, 'auto unit requires natural_size')
+        ---@cast basis number
 
-        ugui.internal.assert(natural, 'auto unit requires natural_size')
-
-        return axis == 'x'
-            and natural.x
-            or natural.y
+        return basis
     end
 
     local s = expr:gsub('^%s+', ''):gsub('%s+$', '')
 
     -- auto
     if s == 'auto' then
-        return natural_basis()
+        return get_natural_basis()
     end
 
     -- px
@@ -364,7 +361,10 @@ local function resolve_unit(expr, node, axis)
         local px = s:match('^([%-%d%.]+)px$')
 
         if px then
-            return tonumber(px)
+            local value = tonumber(px)
+            ugui.internal.assert(value ~= nil, string.format('invalid pixel SmartUnit: %q', s))
+            ---@cast value number
+            return value
         end
     end
 
@@ -373,18 +373,20 @@ local function resolve_unit(expr, node, axis)
         local n = tonumber(s)
 
         if n then
-            return parent_basis() * n
+            return get_parent_basis() * n
         end
     end
 
     ugui.internal.assert(false, string.format('unsupported SmartUnit: %q', s))
+    return 0
 end
 
 ---Resolves a SmartUnit2 to a Vector2.
 ---@param unit SmartUnit2
----@param node SceneNode
+---@param parent_size Vector2?
+---@param natural_size Vector2?
 ---@return Vector2
-ugui.internal.resolve_unit2 = function(unit, node)
+ugui.internal.resolve_unit2 = function(unit, parent_size, natural_size)
     local a, b = unit:match('^(%S+)%s+(%S+)$')
 
     if not a then
@@ -393,8 +395,8 @@ ugui.internal.resolve_unit2 = function(unit, node)
     end
 
     return {
-        x = resolve_unit(a, node, 'x'),
-        y = resolve_unit(b, node, 'y'),
+        x = resolve_unit(a, 'x', parent_size and parent_size.x, natural_size and natural_size.x),
+        y = resolve_unit(b, 'y', parent_size and parent_size.y, natural_size and natural_size.y),
     }
 end
 

--- a/src/ugui/helpers.lua
+++ b/src/ugui/helpers.lua
@@ -342,6 +342,16 @@ local function resolve_unit(expr, node, axis)
             or parent.height
     end
 
+    local function natural_basis()
+        local natural = node.natural_size
+
+        ugui.internal.assert(natural, 'auto unit requires node.natural_size')
+
+        return axis == 'x'
+            and natural.x
+            or natural.y
+    end
+
     local function trim(s)
         return (s:gsub('^%s+', ''):gsub('%s+$', ''))
     end
@@ -403,6 +413,11 @@ local function resolve_unit(expr, node, axis)
 
     local function eval(s)
         s = trim(s)
+
+        -- auto
+        if s == 'auto' then
+            return natural_basis()
+        end
 
         -- min(...)
         do

--- a/src/ugui/helpers.lua
+++ b/src/ugui/helpers.lua
@@ -326,7 +326,7 @@ ugui.internal.print_tree = function(node)
     print('')
 end
 
----Parses and resolves a SmartUnit expression.
+---Parses and resolves a SmartUnit.
 ---@param expr string
 ---@param node SceneNode
 ---@param axis '"x"'|'"y"'
@@ -335,7 +335,7 @@ local function resolve_unit(expr, node, axis)
     local parent = node.parent and node.parent.control.rectangle
 
     local function parent_basis()
-        ugui.internal.assert(parent, 'percentage unit requires parent node')
+        ugui.internal.assert(parent, 'fractional unit requires parent node')
 
         return axis == 'x'
             and parent.width
@@ -352,191 +352,32 @@ local function resolve_unit(expr, node, axis)
             or natural.y
     end
 
-    local function trim(s)
-        return (s:gsub('^%s+', ''):gsub('%s+$', ''))
+    local s = expr:gsub('^%s+', ''):gsub('%s+$', '')
+
+    -- auto
+    if s == 'auto' then
+        return natural_basis()
     end
 
-    local function split_args(s)
-        local args = {}
-        local depth = 0
-        local start = 1
+    -- px
+    do
+        local px = s:match('^([%-%d%.]+)px$')
 
-        for i = 1, #s do
-            local c = s:sub(i, i)
-
-            if c == '(' then
-                depth = depth + 1
-            elseif c == ')' then
-                depth = depth - 1
-            elseif c == ',' and depth == 0 then
-                table.insert(args, trim(s:sub(start, i - 1)))
-                start = i + 1
-            end
-        end
-
-        table.insert(args, trim(s:sub(start)))
-
-        return args
-    end
-
-    local function find_operator(s, operators)
-        local depth = 0
-
-        -- right-to-left for correct precedence grouping
-        for i = #s, 1, -1 do
-            local c = s:sub(i, i)
-
-            if c == ')' then
-                depth = depth + 1
-            elseif c == '(' then
-                depth = depth - 1
-            elseif depth == 0 then
-                for _, op in ipairs(operators) do
-                    if c == op then
-                        -- skip unary minus
-                        if op == '-' then
-                            local prev = s:sub(i - 1, i - 1)
-
-                            if i == 1 or prev:match('[%+%-%*/%(,]') then
-                                goto continue
-                            end
-                        end
-
-                        return i, op
-                    end
-                end
-            end
-
-            ::continue::
+        if px then
+            return tonumber(px)
         end
     end
 
-    local function eval(s)
-        s = trim(s)
+    -- parent-relative fraction
+    do
+        local n = tonumber(s)
 
-        -- auto
-        if s == 'auto' then
-            return natural_basis()
+        if n then
+            return parent_basis() * n
         end
-
-        -- min(...)
-        do
-            local inner = s:match('^min%((.*)%)$')
-
-            if inner then
-                local args = split_args(inner)
-
-                ugui.internal.assert(#args == 2, 'min() expects 2 arguments')
-
-                return math.min(
-                    eval(args[1]),
-                    eval(args[2])
-                )
-            end
-        end
-
-        -- max(...)
-        do
-            local inner = s:match('^max%((.*)%)$')
-
-            if inner then
-                local args = split_args(inner)
-
-                ugui.internal.assert(#args == 2, 'max() expects 2 arguments')
-
-                return math.max(
-                    eval(args[1]),
-                    eval(args[2])
-                )
-            end
-        end
-
-        -- clamp(...)
-        do
-            local inner = s:match('^clamp%((.*)%)$')
-
-            if inner then
-                local args = split_args(inner)
-
-                ugui.internal.assert(#args == 3, 'clamp() expects 3 arguments')
-
-                local v = eval(args[1])
-                local mn = eval(args[2])
-                local mx = eval(args[3])
-
-                return math.max(mn, math.min(mx, v))
-            end
-        end
-
-        -- parenthesized expression
-        if s:match('^%b()$') then
-            return eval(s:sub(2, -2))
-        end
-
-        -- + -
-        do
-            local i, op = find_operator(s, {'+', '-'})
-
-            if i then
-                local lhs = eval(s:sub(1, i - 1))
-                local rhs = eval(s:sub(i + 1))
-
-                return op == '+'
-                    and (lhs + rhs)
-                    or (lhs - rhs)
-            end
-        end
-
-        -- * /
-        do
-            local i, op = find_operator(s, {'*', '/'})
-
-            if i then
-                local lhs = eval(s:sub(1, i - 1))
-                local rhs = eval(s:sub(i + 1))
-
-                return op == '*'
-                    and (lhs * rhs)
-                    or (lhs / rhs)
-            end
-        end
-
-        -- px
-        do
-            local px = s:match('^([%-%d%.]+)px$')
-
-            if px then
-                return tonumber(px)
-            end
-        end
-
-        -- %
-        do
-            local percent = s:match('^([%-%d%.]+)%%$')
-
-            if percent then
-                return parent_basis() * (tonumber(percent) / 100)
-            end
-        end
-
-        -- zero literal
-        if s == '0' then
-            return 0
-        end
-
-        -- raw number
-        do
-            local n = tonumber(s)
-
-            if n then
-                return n
-            end
-        end
-
-        ugui.internal.assert(false, string.format('unsupported SmartUnit: %q', s))
     end
 
-    return eval(expr)
+    ugui.internal.assert(false, string.format('unsupported SmartUnit: %q', s))
 end
 
 ---Resolves a SmartUnit2 to a Vector2.

--- a/src/ugui/helpers.lua
+++ b/src/ugui/helpers.lua
@@ -281,15 +281,15 @@ ugui.internal.control_from_point = function(pt)
     return result
 end
 
----Finds a control by its UID.
----@param uid UID? The UID of the control to find. If `nil`, returns `nil`.
----@return Control? The control with the given UID, or `nil` if no control is found.
-ugui.internal.find_control_by_uid = function(uid)
+---Finds a scene node by its control's UID.
+---@param uid UID?
+---@return SceneNode?
+ugui.internal.find_node = function(uid)
     if uid == nil then return nil end
     local result = nil
     ugui.internal.foreach_node_from_root(function(node)
         if node.control.uid == uid then
-            result = node.control
+            result = node
             return false
         end
     end)

--- a/src/ugui/helpers.lua
+++ b/src/ugui/helpers.lua
@@ -402,52 +402,15 @@ end
 
 ---Parses and resolves a SmartAlignment.
 ---@param value string
----@param axis '"x"'|'"y"'
 ---@return number
-local function resolve_alignment(value, axis)
+local function resolve_alignment(value)
     value = value:gsub('^%s+', ''):gsub('%s+$', '')
 
-    -- directional aliases
-    if value == 'left' then
-        ugui.internal.assert(axis == 'x', '`left` is only valid on the X axis')
-        return 0
-    end
-
-    if value == 'right' then
-        ugui.internal.assert(axis == 'x', '`right` is only valid on the X axis')
-        return 1
-    end
-
-    if value == 'top' then
-        ugui.internal.assert(axis == 'y', '`top` is only valid on the Y axis')
-        return 0
-    end
-
-    if value == 'bottom' then
-        ugui.internal.assert(axis == 'y', '`bottom` is only valid on the Y axis')
-        return 1
-    end
-
-    if value == 'center' then
-        return 0.5
-    end
-
-    -- percentage
-    do
-        local percent = value:match('^([%-%d%.]+)%%$')
-
-        if percent then
-            return tonumber(percent) / 100
-        end
-    end
-
     -- raw normalized number
-    do
-        local n = tonumber(value)
+    local n = tonumber(value)
 
-        if n then
-            return n
-        end
+    if n then
+        return n
     end
 
     ugui.internal.assert(
@@ -466,20 +429,11 @@ ugui.internal.resolve_alignment2 = function(value)
 
     if not a then
         a = value
-
-        -- directional single-value expansion
-        if value == 'left' or value == 'right' then
-            b = 'top'
-        elseif value == 'top' or value == 'bottom' then
-            b = value
-            a = 'left'
-        else
-            b = value
-        end
+        b = value
     end
 
     return {
-        x = resolve_alignment(a, 'x'),
-        y = resolve_alignment(b, 'y'),
+        x = resolve_alignment(a),
+        y = resolve_alignment(b),
     }
 end

--- a/src/ugui/helpers.lua
+++ b/src/ugui/helpers.lua
@@ -556,3 +556,87 @@ ugui.internal.resolve_unit2 = function(unit, node)
         y = resolve_unit(b, node, 'y'),
     }
 end
+
+---Parses and resolves a SmartAlignment.
+---@param value string
+---@param axis '"x"'|'"y"'
+---@return number
+local function resolve_alignment(value, axis)
+    value = value:gsub('^%s+', ''):gsub('%s+$', '')
+
+    -- directional aliases
+    if value == 'left' then
+        ugui.internal.assert(axis == 'x', '`left` is only valid on the X axis')
+        return 0
+    end
+
+    if value == 'right' then
+        ugui.internal.assert(axis == 'x', '`right` is only valid on the X axis')
+        return 1
+    end
+
+    if value == 'top' then
+        ugui.internal.assert(axis == 'y', '`top` is only valid on the Y axis')
+        return 0
+    end
+
+    if value == 'bottom' then
+        ugui.internal.assert(axis == 'y', '`bottom` is only valid on the Y axis')
+        return 1
+    end
+
+    if value == 'center' then
+        return 0.5
+    end
+
+    -- percentage
+    do
+        local percent = value:match('^([%-%d%.]+)%%$')
+
+        if percent then
+            return tonumber(percent) / 100
+        end
+    end
+
+    -- raw normalized number
+    do
+        local n = tonumber(value)
+
+        if n then
+            return n
+        end
+    end
+
+    ugui.internal.assert(
+        false,
+        string.format('unsupported SmartAlignment: %q', value)
+    )
+end
+
+---Resolves a SmartAlignment2 to a Vector2.
+---@param value SmartAlignment2?
+---@return Vector2
+ugui.internal.resolve_alignment2 = function(value)
+    value = value or '0'
+
+    local a, b = value:match('^(%S+)%s+(%S+)$')
+
+    if not a then
+        a = value
+
+        -- directional single-value expansion
+        if value == 'left' or value == 'right' then
+            b = 'top'
+        elseif value == 'top' or value == 'bottom' then
+            b = value
+            a = 'left'
+        else
+            b = value
+        end
+    end
+
+    return {
+        x = resolve_alignment(a, 'x'),
+        y = resolve_alignment(b, 'y'),
+    }
+end

--- a/src/ugui/helpers.lua
+++ b/src/ugui/helpers.lua
@@ -343,9 +343,9 @@ local function resolve_unit(expr, node, axis)
     end
 
     local function natural_basis()
-        local natural = node.natural_size
+        local natural = ugui.internal.control_data[node.control.uid].natural_size
 
-        ugui.internal.assert(natural, 'auto unit requires node.natural_size')
+        ugui.internal.assert(natural, 'auto unit requires natural_size')
 
         return axis == 'x'
             and natural.x

--- a/src/ugui/helpers.lua
+++ b/src/ugui/helpers.lua
@@ -267,3 +267,18 @@ ugui.internal.control_from_point = function(pt)
     end)
     return result
 end
+
+---Finds a control by its UID.
+---@param uid UID? The UID of the control to find. If `nil`, returns `nil`.
+---@return Control? The control with the given UID, or `nil` if no control is found.
+ugui.internal.find_control_by_uid = function(uid)
+    if uid == nil then return nil end
+    local result = nil
+    ugui.internal.foreach_node_from_root(function(node)
+        if node.control.uid == uid then
+            result = node.control
+            return false
+        end
+    end)
+    return result
+end

--- a/src/ugui/helpers.lua
+++ b/src/ugui/helpers.lua
@@ -216,7 +216,20 @@ end
 ---Traverses a tree node depth-first and invokes a callback function for each node.
 ---@param node table The node to traverse.
 ---@param callback fun(node: SceneNode): boolean? The callback function to invoke for each node. If the callback returns `false`, the traversal is stopped early.
-ugui.internal.foreach_node = function(node, callback)
+---@param reverse boolean? Whether to traverse children in reverse order.
+ugui.internal.foreach_node = function(node, callback, reverse)
+    if reverse then
+        for i = #node.children, 1, -1 do
+            if ugui.internal.foreach_node(node.children[i], callback, reverse) == false then
+                return
+            end
+        end
+        if callback(node) == false then
+            return
+        end
+        return
+    end
+
     if callback(node) == false then
         return
     end
@@ -281,4 +294,34 @@ ugui.internal.find_control_by_uid = function(uid)
         end
     end)
     return result
+end
+
+
+---Prints the scene tree for debugging purposes.
+---@param node SceneNode
+ugui.internal.print_tree = function(node)
+    ---@param node SceneNode
+    local function print_tree_impl(node, prefix, is_last)
+        prefix = prefix or ''
+        local connector = is_last and '└─ ' or '├─ '
+
+        local label = ''
+        if node == ugui.internal.root then
+            label = '<root>'
+        end
+        label = label .. ' ' .. node.type .. ' ' .. tostring(node.control.uid)
+
+        print(prefix .. connector .. label)
+        print(prefix .. '      ' .. string.format('rect: (%.0f, %.0f) %.0f x %.0f', node.control.rectangle.x, node.control.rectangle.y, node.control.rectangle.width, node.control.rectangle.height))
+
+        local child_prefix = prefix .. (is_last and '   ' or '│  ')
+
+        local children = node.children or {}
+        for i, child in pairs(children) do
+            print_tree_impl(child, child_prefix, i == #children)
+        end
+    end
+
+    print_tree_impl(node)
+    print('')
 end

--- a/src/ugui/helpers.lua
+++ b/src/ugui/helpers.lua
@@ -326,32 +326,204 @@ ugui.internal.print_tree = function(node)
     print('')
 end
 
+---Parses and resolves a SmartUnit expression.
+---@param expr string
+---@param node SceneNode
+---@param axis '"x"'|'"y"'
+---@return number
+local function resolve_unit(expr, node, axis)
+    local parent = node.parent and node.parent.control.rectangle
+
+    local function parent_basis()
+        ugui.internal.assert(parent, 'percentage unit requires parent node')
+
+        return axis == 'x'
+            and parent.width
+            or parent.height
+    end
+
+    local function trim(s)
+        return (s:gsub('^%s+', ''):gsub('%s+$', ''))
+    end
+
+    local function split_args(s)
+        local args = {}
+        local depth = 0
+        local start = 1
+
+        for i = 1, #s do
+            local c = s:sub(i, i)
+
+            if c == '(' then
+                depth = depth + 1
+            elseif c == ')' then
+                depth = depth - 1
+            elseif c == ',' and depth == 0 then
+                table.insert(args, trim(s:sub(start, i - 1)))
+                start = i + 1
+            end
+        end
+
+        table.insert(args, trim(s:sub(start)))
+
+        return args
+    end
+
+    local function find_operator(s, operators)
+        local depth = 0
+
+        -- right-to-left for correct precedence grouping
+        for i = #s, 1, -1 do
+            local c = s:sub(i, i)
+
+            if c == ')' then
+                depth = depth + 1
+            elseif c == '(' then
+                depth = depth - 1
+            elseif depth == 0 then
+                for _, op in ipairs(operators) do
+                    if c == op then
+                        -- skip unary minus
+                        if op == '-' then
+                            local prev = s:sub(i - 1, i - 1)
+
+                            if i == 1 or prev:match('[%+%-%*/%(,]') then
+                                goto continue
+                            end
+                        end
+
+                        return i, op
+                    end
+                end
+            end
+
+            ::continue::
+        end
+    end
+
+    local function eval(s)
+        s = trim(s)
+
+        -- min(...)
+        do
+            local inner = s:match('^min%((.*)%)$')
+
+            if inner then
+                local args = split_args(inner)
+
+                ugui.internal.assert(#args == 2, 'min() expects 2 arguments')
+
+                return math.min(
+                    eval(args[1]),
+                    eval(args[2])
+                )
+            end
+        end
+
+        -- max(...)
+        do
+            local inner = s:match('^max%((.*)%)$')
+
+            if inner then
+                local args = split_args(inner)
+
+                ugui.internal.assert(#args == 2, 'max() expects 2 arguments')
+
+                return math.max(
+                    eval(args[1]),
+                    eval(args[2])
+                )
+            end
+        end
+
+        -- clamp(...)
+        do
+            local inner = s:match('^clamp%((.*)%)$')
+
+            if inner then
+                local args = split_args(inner)
+
+                ugui.internal.assert(#args == 3, 'clamp() expects 3 arguments')
+
+                local v = eval(args[1])
+                local mn = eval(args[2])
+                local mx = eval(args[3])
+
+                return math.max(mn, math.min(mx, v))
+            end
+        end
+
+        -- parenthesized expression
+        if s:match('^%b()$') then
+            return eval(s:sub(2, -2))
+        end
+
+        -- + -
+        do
+            local i, op = find_operator(s, {'+', '-'})
+
+            if i then
+                local lhs = eval(s:sub(1, i - 1))
+                local rhs = eval(s:sub(i + 1))
+
+                return op == '+'
+                    and (lhs + rhs)
+                    or (lhs - rhs)
+            end
+        end
+
+        -- * /
+        do
+            local i, op = find_operator(s, {'*', '/'})
+
+            if i then
+                local lhs = eval(s:sub(1, i - 1))
+                local rhs = eval(s:sub(i + 1))
+
+                return op == '*'
+                    and (lhs * rhs)
+                    or (lhs / rhs)
+            end
+        end
+
+        -- px
+        do
+            local px = s:match('^([%-%d%.]+)px$')
+
+            if px then
+                return tonumber(px)
+            end
+        end
+
+        -- %
+        do
+            local percent = s:match('^([%-%d%.]+)%%$')
+
+            if percent then
+                return parent_basis() * (tonumber(percent) / 100)
+            end
+        end
+
+        -- raw number
+        do
+            local n = tonumber(s)
+
+            if n then
+                return n
+            end
+        end
+
+        ugui.internal.assert(false, string.format('unsupported SmartUnit: %q', s))
+    end
+
+    return eval(expr)
+end
+
 ---Resolves a SmartUnit2 to a Vector2.
 ---@param unit SmartUnit2
 ---@param node SceneNode
 ---@return Vector2
 ugui.internal.resolve_unit2 = function(unit, node)
-    local function resolve_unit(unit, axis)
-        local px = unit:match('^([%-%d%.]+)px$')
-
-        if px then
-            return tonumber(px)
-        end
-
-        local percent = unit:match('^([%-%d%.]+)%%$')
-
-        if percent then
-            ugui.internal.assert(node.parent, 'percentage unit requires parent node')
-
-            local parent_rc = node.parent.control.rectangle
-            local basis = axis == 'x' and parent_rc.width or parent_rc.height
-
-            return basis * (tonumber(percent) / 100)
-        end
-
-        ugui.internal.assert(false, string.format('unsupported SmartUnit: %q', unit))
-    end
-
     local a, b = unit:match('^(%S+)%s+(%S+)$')
 
     if not a then
@@ -360,7 +532,7 @@ ugui.internal.resolve_unit2 = function(unit, node)
     end
 
     return {
-        x = resolve_unit(a, 'x'),
-        y = resolve_unit(b, 'y'),
+        x = resolve_unit(a, node, 'x'),
+        y = resolve_unit(b, node, 'y'),
     }
 end

--- a/src/ugui/helpers.lua
+++ b/src/ugui/helpers.lua
@@ -519,6 +519,11 @@ local function resolve_unit(expr, node, axis)
             end
         end
 
+        -- zero literal
+        if s == '0' then
+            return 0
+        end
+
         -- raw number
         do
             local n = tonumber(s)

--- a/src/ugui/helpers.lua
+++ b/src/ugui/helpers.lua
@@ -325,3 +325,28 @@ ugui.internal.print_tree = function(node)
     print_tree_impl(node)
     print('')
 end
+
+
+---Resolves a SmartUnit2 to a Vector2.
+---@param unit SmartUnit2
+---@param node SceneNode
+---@return Vector2
+ugui.internal.resolve_unit2 = function(unit, node)
+    local function resolve_unit(unit)
+        local px = unit:match('^([%-%d%.]+)px$')
+        ugui.internal.assert(px, string.format('unsupported SmartUnit: %q', unit))
+        return tonumber(px)
+    end
+
+    local a, b = unit:match('^(%S+)%s+(%S+)$')
+
+    if not a then
+        a = unit
+        b = unit
+    end
+
+    return {
+        x = resolve_unit(a),
+        y = resolve_unit(b),
+    }
+end

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -435,8 +435,14 @@ ugui.internal = {
         end
 
         local control = node.control
+        local data = ugui.internal.control_data[control.uid]
+        local parent_size = node.parent and {
+            x = node.parent.control.rectangle.width,
+            y = node.parent.control.rectangle.height,
+        }
+
         if control.padding then
-            local padding = ugui.internal.resolve_unit2(control.padding, node)
+            local padding = ugui.internal.resolve_unit2(control.padding, parent_size, data.natural_size)
             biggest.x = biggest.x + padding.x * 2
             biggest.y = biggest.y + padding.y * 2
         end
@@ -452,13 +458,19 @@ ugui.internal = {
 
         ugui.internal.foreach_node_from_root(function(node)
             local control = node.control
+            local data = ugui.internal.control_data[control.uid]
+            local parent_size = node.parent and {
+                x = node.parent.control.rectangle.width,
+                y = node.parent.control.rectangle.height,
+            }
+
             if control.margin then
-                local pos = ugui.internal.resolve_unit2(control.margin, node)
+                local pos = ugui.internal.resolve_unit2(control.margin, parent_size, data.natural_size)
                 control.rectangle.x = pos.x
                 control.rectangle.y = pos.y
             end
             if control.size then
-                local size = ugui.internal.resolve_unit2(control.size, node)
+                local size = ugui.internal.resolve_unit2(control.size, parent_size, data.natural_size)
                 control.rectangle.width = size.x
                 control.rectangle.height = size.y
             end
@@ -472,7 +484,12 @@ ugui.internal = {
             local parent_padding = {x = 0, y = 0}
 
             if parent and parent.control.padding then
-                parent_padding = ugui.internal.resolve_unit2(parent.control.padding, parent)
+                local parent_data = ugui.internal.control_data[parent.control.uid]
+                local grandparent_size = parent.parent and {
+                    x = parent.parent.control.rectangle.width,
+                    y = parent.parent.control.rectangle.height,
+                }
+                parent_padding = ugui.internal.resolve_unit2(parent.control.padding, grandparent_size, parent_data.natural_size)
             end
 
             local min_x<const> = parent_rect.x + parent_padding.x

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -489,6 +489,11 @@ ugui.internal = {
             control.rectangle.x = control.rectangle.x + x_offset
             control.rectangle.y = control.rectangle.y + y_offset
         end)
+
+        ugui.internal.foreach_node_from_root(function(node)
+            local data = ugui.internal.control_data[node.control.uid]
+            data.render_rect = {x = node.control.rectangle.x, y = node.control.rectangle.y, width = node.control.rectangle.width, height = node.control.rectangle.height}
+        end)
     end,
 
     render = function()

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -7,7 +7,6 @@
 ---@class SceneNode
 ---@field public control Control
 ---@field public type ControlType
----@field public natural_size Vector2
 ---@field public parent SceneNode?
 ---@field public children SceneNode[]
 
@@ -448,7 +447,7 @@ ugui.internal = {
     ---Performs scene layout.
     layout = function()
         ugui.internal.foreach_node_from_root(function(node)
-            node.natural_size = ugui.internal.measure(node)
+            ugui.internal.control_data[node.control.uid].natural_size = ugui.internal.measure(node)
         end)
 
         ugui.internal.foreach_node_from_root(function(node)

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -238,13 +238,13 @@ ugui.internal = {
             return
         end
 
-        local hovered_control = ugui.internal.find_control_by_uid(ugui.internal.hovered_control)
+        local hovered_node = ugui.internal.find_node(ugui.internal.hovered_control)
 
-        if not hovered_control then
+        if not hovered_node then
             return
         end
 
-        ugui.standard_styler.draw_tooltip(hovered_control, {
+        ugui.standard_styler.draw_tooltip(hovered_node.control, {
             x = ugui.internal.environment.mouse_position.x,
             y = ugui.internal.environment.mouse_position.y,
         })
@@ -323,32 +323,19 @@ ugui.internal = {
             callback(node)
         end
 
-        local function find_control_by_uid(node, uid)
-            if node.control.uid == uid then
-                return node
-            end
-            for _, child in ipairs(node.children) do
-                local found = find_control_by_uid(child, uid)
-                if found then
-                    return found
-                end
-            end
-            return nil
-        end
-
         ---@type Control?
         local clicked_control = nil
 
         ---@type SceneNode?
         local mouse_captured_control = nil
         if ugui.internal.mouse_captured_control then
-            mouse_captured_control = find_control_by_uid(ugui.internal.root, ugui.internal.mouse_captured_control)
+            mouse_captured_control = ugui.internal.find_node(ugui.internal.mouse_captured_control)
         end
 
         ---@type SceneNode?
         local keyboard_captured_control = nil
         if ugui.internal.keyboard_captured_control then
-            keyboard_captured_control = find_control_by_uid(ugui.internal.root, ugui.internal.keyboard_captured_control)
+            keyboard_captured_control = ugui.internal.find_node(ugui.internal.keyboard_captured_control)
         end
 
         local prev_hovered_control = ugui.internal.hovered_control
@@ -405,7 +392,7 @@ ugui.internal = {
         end
 
         -- Clear hovered control if it's disabled
-        local hovered_node = ugui.internal.hovered_control and find_control_by_uid(ugui.internal.root, ugui.internal.hovered_control) or nil
+        local hovered_node = ugui.internal.hovered_control and ugui.internal.find_node(ugui.internal.hovered_control) or nil
         if hovered_node and hovered_node.control.is_enabled == false then
             ugui.internal.hovered_control = nil
         end

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -500,6 +500,9 @@ ugui.internal = {
             local control = node.control
             local type = node.type
 
+            local data = ugui.internal.control_data[node.control.uid]
+            local render_rect = data.render_rect
+
             local entry = ugui.registry[type]
 
             if entry.draw then
@@ -509,14 +512,14 @@ ugui.internal = {
             end
 
             if ugui.DEBUG then
-                -- BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle(control.rectangle, 0), '#FF0000', 1)
-                -- BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle({x = control.rectangle.x, y = control.rectangle.y, width = node.natural_size.x, height = node.natural_size.y}, 0), '#0000FF', 4)
+                BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle(render_rect, 0), '#FF0000', 1)
+                -- BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle({x = render_rect.x, y = render_rect.y, width = data.natural_size.x, height = data.natural_size.y}, 0), '#0000FF', 4)
 
                 if ugui.internal.keyboard_captured_control == control.uid then
-                    BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle(control.rectangle, 4), '#000000', 2)
+                    BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle(render_rect, 4), '#000000', 2)
                 end
                 if ugui.internal.mouse_captured_control == control.uid then
-                    BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle(control.rectangle, 8), '#FF0000', 2)
+                    BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle(render_rect, 8), '#FF0000', 2)
                 end
             end
         end)

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -482,8 +482,9 @@ ugui.internal = {
             local min_y<const> = parent_rect.y
             local max_y<const> = min_y + parent_rect.height - control.rectangle.height
 
-            local x_offset<const> = ugui.internal.remap(control.x_align or 0, 0, 1, min_x, max_x)
-            local y_offset<const> = ugui.internal.remap(control.y_align or 0, 0, 1, min_y, max_y)
+            local align = ugui.internal.resolve_alignment2(control.align)
+            local x_offset<const> = ugui.internal.remap(align.x, 0, 1, min_x, max_x)
+            local y_offset<const> = ugui.internal.remap(align.y, 0, 1, min_y, max_y)
 
             control.rectangle.x = control.rectangle.x + x_offset
             control.rectangle.y = control.rectangle.y + y_offset
@@ -504,7 +505,7 @@ ugui.internal = {
             end
 
             if ugui.DEBUG then
-                BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle(control.rectangle, 0), '#FF0000', 1)
+                -- BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle(control.rectangle, 0), '#FF0000', 1)
                 -- BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle({x = control.rectangle.x, y = control.rectangle.y, width = node.natural_size.x, height = node.natural_size.y}, 0), '#0000FF', 4)
 
                 if ugui.internal.keyboard_captured_control == control.uid then

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -7,6 +7,7 @@
 ---@class SceneNode
 ---@field public control Control
 ---@field public type ControlType
+---@field public natural_size Vector2
 ---@field public parent SceneNode?
 ---@field public children SceneNode[]
 
@@ -424,8 +425,51 @@ ugui.internal = {
         ugui.internal.clicked_control = clicked_control and clicked_control.uid or nil
     end,
 
+    ---Measures the specified node.
+    ---@param node SceneNode
+    ---@return Vector2
+    measure = function(node)
+        local registry_entry = ugui.registry[node.type]
+        if registry_entry.measure then
+            return registry_entry.measure(node)
+        end
+        return ugui.internal.measure_fit_biggest_child(node)
+    end,
+
+    ---Default measure implementation that fits the biggest child node recursively.
+    ---@param node SceneNode
+    ---@return Vector2
+    measure_fit_biggest_child = function(node)
+        local biggest = {x = 0, y = 0}
+        for _, child in pairs(node.children) do
+            local size = ugui.internal.measure(child)
+            if size.x > biggest.x or size.y > biggest.y then
+                biggest = size
+            end
+        end
+        return biggest
+    end,
+
     ---Performs scene layout.
     layout = function()
+        ugui.internal.foreach_node_from_root(function(node)
+            node.natural_size = ugui.internal.measure(node)
+        end)
+
+        ugui.internal.foreach_node_from_root(function(node)
+            local control = node.control
+            if control.margin then
+                local pos = ugui.internal.resolve_unit2(control.margin, node)
+                control.rectangle.x = pos.x
+                control.rectangle.y = pos.y
+            end
+            if control.size then
+                local size = ugui.internal.resolve_unit2(control.size, node)
+                control.rectangle.width = size.x
+                control.rectangle.height = size.y
+            end
+        end)
+
         ugui.internal.foreach_node_from_root(function(node)
             local control = node.control
             local parent = node.parent
@@ -443,6 +487,33 @@ ugui.internal = {
 
             control.rectangle.x = control.rectangle.x + x_offset
             control.rectangle.y = control.rectangle.y + y_offset
+        end)
+    end,
+
+    render = function()
+        ugui.internal.foreach_node_from_root(function(node)
+            local control = node.control
+            local type = node.type
+
+            local entry = ugui.registry[type]
+
+            if entry.draw then
+                local revert_styler_mixin = ugui.internal.apply_styler_mixin(control)
+                entry.draw(control)
+                revert_styler_mixin()
+            end
+
+            if ugui.DEBUG then
+                BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle(control.rectangle, 0), '#FF0000', 1)
+                -- BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle({x = control.rectangle.x, y = control.rectangle.y, width = node.natural_size.x, height = node.natural_size.y}, 0), '#0000FF', 4)
+
+                if ugui.internal.keyboard_captured_control == control.uid then
+                    BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle(control.rectangle, 4), '#000000', 2)
+                end
+                if ugui.internal.mouse_captured_control == control.uid then
+                    BreitbandGraphics.draw_rectangle(BreitbandGraphics.inflate_rectangle(control.rectangle, 8), '#FF0000', 2)
+                end
+            end
         end)
     end,
 }

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -4,7 +4,11 @@
 -- SPDX-License-Identifier: GPL-3.0-or-later
 --
 
----@alias SceneNode { control: Control, type: ControlType, parent: SceneNode?, children: SceneNode[] }
+---@class SceneNode
+---@field public control Control
+---@field public type ControlType
+---@field public parent SceneNode?
+---@field public children SceneNode[]
 
 ugui.internal = {
     ---@type SceneNode

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -434,6 +434,14 @@ ugui.internal = {
                 biggest = size
             end
         end
+
+        local control = node.control
+        if control.padding then
+            local padding = ugui.internal.resolve_unit2(control.padding, node)
+            biggest.x = biggest.x + padding.x * 2
+            biggest.y = biggest.y + padding.y * 2
+        end
+
         return biggest
     end,
 
@@ -462,12 +470,17 @@ ugui.internal = {
             local parent = node.parent
 
             local parent_rect = parent and parent.control.rectangle or {x = 0, y = 0, width = 0, height = 0}
+            local parent_padding = {x = 0, y = 0}
 
-            local min_x<const> = parent_rect.x
-            local max_x<const> = min_x + parent_rect.width - control.rectangle.width
+            if parent and parent.control.padding then
+                parent_padding = ugui.internal.resolve_unit2(parent.control.padding, parent)
+            end
 
-            local min_y<const> = parent_rect.y
-            local max_y<const> = min_y + parent_rect.height - control.rectangle.height
+            local min_x<const> = parent_rect.x + parent_padding.x
+            local max_x<const> = min_x + parent_rect.width - parent_padding.x * 2 - control.rectangle.width
+
+            local min_y<const> = parent_rect.y + parent_padding.y
+            local max_y<const> = min_y + parent_rect.height - parent_padding.y * 2 - control.rectangle.height
 
             local align = ugui.internal.resolve_alignment2(control.align)
             local x_offset<const> = ugui.internal.remap(align.x, 0, 1, min_x, max_x)

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -433,20 +433,6 @@ ugui.internal = {
                 biggest = size
             end
         end
-
-        local control = node.control
-        local data = ugui.internal.control_data[control.uid]
-        local parent_size = node.parent and {
-            x = node.parent.control.rectangle.width,
-            y = node.parent.control.rectangle.height,
-        }
-
-        if control.padding then
-            local padding = ugui.internal.resolve_unit2(control.padding, parent_size, data.natural_size)
-            biggest.x = biggest.x + padding.x * 2
-            biggest.y = biggest.y + padding.y * 2
-        end
-
         return biggest
     end,
 
@@ -474,6 +460,14 @@ ugui.internal = {
                 control.rectangle.width = size.x
                 control.rectangle.height = size.y
             end
+
+            if control.padding then
+                data.computed_padding = ugui.internal.resolve_unit2(control.padding, parent_size, data.natural_size)
+                control.rectangle.width = control.rectangle.width + data.computed_padding.x * 2
+                control.rectangle.height = control.rectangle.height + data.computed_padding.y * 2
+            else
+                data.computed_padding = { x = 0, y = 0 }
+            end
         end)
 
         ugui.internal.foreach_node_from_root(function(node)
@@ -486,10 +480,13 @@ ugui.internal = {
             if parent and parent.control.padding then
                 local parent_data = ugui.internal.control_data[parent.control.uid]
                 local grandparent_size = parent.parent and {
-                    x = parent.parent.control.rectangle.width,
-                    y = parent.parent.control.rectangle.height,
+                        x = parent.parent.control.rectangle.width,
+                        y = parent.parent.control.rectangle.height,
                 }
-                parent_padding = ugui.internal.resolve_unit2(parent.control.padding, grandparent_size, parent_data.natural_size)
+                parent_padding = ugui.internal.resolve_unit2(parent.control.padding, grandparent_size,
+                    parent_data.natural_size)
+                parent_padding.x = parent_padding.x * 0.5
+                parent_padding.y = parent_padding.y * 0.5
             end
 
             local min_x<const> = parent_rect.x + parent_padding.x

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -224,19 +224,22 @@ ugui.internal = {
         if ugui.internal.hovered_control == nil then
             return
         end
+
         if (os.clock() - ugui.internal.hover_start_time) < ugui.standard_styler.params.tooltip.delay then
             return
         end
 
-        -- Find hovered control
-        for _, entry in pairs(ugui.internal.root) do
-            if entry.control.uid == ugui.internal.hovered_control then
-                ugui.standard_styler.draw_tooltip(entry.control, {
-                    x = ugui.internal.environment.mouse_position.x,
-                    y = ugui.internal.environment.mouse_position.y,
-                })
-            end
+        local hovered_control = ugui.internal.find_control_by_uid(ugui.internal.hovered_control)
+
+        if not hovered_control then
+            return
         end
+
+
+        ugui.standard_styler.draw_tooltip(hovered_control, {
+            x = ugui.internal.environment.mouse_position.x,
+            y = ugui.internal.environment.mouse_position.y,
+        })
     end,
 
     ---Parses rich text into content segments.

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -4,11 +4,15 @@
 -- SPDX-License-Identifier: GPL-3.0-or-later
 --
 
----@alias SceneNode { control: Control, type: ControlType, children: SceneNode[] }
+---@alias SceneNode { control: Control, type: ControlType, parent: SceneNode?, children: SceneNode[] }
 
 ugui.internal = {
     ---@type SceneNode
-    root = {},
+    root = nil,
+
+    ---@type SceneNode
+    ---The current parent node for controls being placed. Reset to the root node each frame.
+    current_parent = nil,
 
     ---@type table<UID, ControlType>
     control_types = {},
@@ -235,7 +239,6 @@ ugui.internal = {
             return
         end
 
-
         ugui.standard_styler.draw_tooltip(hovered_control, {
             x = ugui.internal.environment.mouse_position.x,
             y = ugui.internal.environment.mouse_position.y,
@@ -415,5 +418,20 @@ ugui.internal = {
         ugui.internal.mouse_captured_control = mouse_captured_control and mouse_captured_control.control.uid or nil
         ugui.internal.keyboard_captured_control = keyboard_captured_control and keyboard_captured_control.control.uid or nil
         ugui.internal.clicked_control = clicked_control and clicked_control.uid or nil
+    end,
+
+    ---Performs scene layout.
+    layout = function()
+        -- Our basic layout rules for now:
+        -- control.rectangle x/y are considered offsets from the parent's x/y
+
+        ugui.internal.foreach_node_from_root(function(node)
+            local control = node.control
+            local parent = node.parent
+
+
+            control.rectangle.x = control.rectangle.x + (parent and parent.control.rectangle.x or 0)
+            control.rectangle.y = control.rectangle.y + (parent and parent.control.rectangle.y or 0)
+        end)
     end,
 }

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -4,11 +4,11 @@
 -- SPDX-License-Identifier: GPL-3.0-or-later
 --
 
----@alias SceneEntry { control: Control, type: ControlType }
+---@alias SceneNode { control: Control, type: ControlType, children: SceneNode[] }
 
 ugui.internal = {
-    ---@type SceneEntry[]
-    scene = {},
+    ---@type SceneNode
+    root = {},
 
     ---@type table<UID, ControlType>
     control_types = {},
@@ -63,31 +63,26 @@ ugui.internal = {
     ---Cache of nineslice drawings. Only used after calling `ugui.apply_nineslice`.
     nineslice_draw_cache = {},
 
-    ---Sorts controls stably in the scene by their Z-index.
-    sort_scene = function()
-        ugui.internal.stable_sort(ugui.internal.scene, function(a, b)
-            return (a.control.z_index or 0) < (b.control.z_index or 0)
-        end)
-    end,
-
     ---Dispatches events related to controls in the scene.
     dispatch_events = function()
-        for _, value in pairs(ugui.internal.scene) do
+        ugui.internal.foreach_node_from_root(function(node)
+            local control = node.control
+            local registry_entry = ugui.registry[node.type]
+
             local existed_in_previous_frame = false
             for uid, _ in pairs(ugui.internal.previous_uids) do
-                if value.control.uid == uid then
+                if control.uid == uid then
                     existed_in_previous_frame = true
                     break
                 end
             end
 
             if not existed_in_previous_frame then
-                local registry_entry = ugui.registry[value.type]
                 if registry_entry.added then
-                    registry_entry.added(value.control, ugui.internal.control_data[value.control.uid])
+                    registry_entry.added(control, ugui.internal.control_data[control.uid])
                 end
             end
-        end
+        end)
     end,
 
 
@@ -234,7 +229,7 @@ ugui.internal = {
         end
 
         -- Find hovered control
-        for _, entry in pairs(ugui.internal.scene) do
+        for _, entry in pairs(ugui.internal.root) do
             if entry.control.uid == ugui.internal.hovered_control then
                 ugui.standard_styler.draw_tooltip(entry.control, {
                     x = ugui.internal.environment.mouse_position.x,
@@ -309,35 +304,48 @@ ugui.internal = {
                 point.y <= rectangle.y + rectangle.height
         end
 
+        local function traverse_tree_reversed(node, callback)
+            for i = #node.children, 1, -1 do
+                traverse_tree_reversed(node.children[i], callback)
+            end
+
+            callback(node)
+        end
+
+        local function find_control_by_uid(node, uid)
+            if node.control.uid == uid then
+                return node
+            end
+            for _, child in ipairs(node.children) do
+                local found = find_control_by_uid(child, uid)
+                if found then
+                    return found
+                end
+            end
+            return nil
+        end
+
         ---@type Control?
         local clicked_control = nil
 
-        ---@type SceneEntry?
+        ---@type SceneNode?
         local mouse_captured_control = nil
-        for i = 1, #ugui.internal.scene, 1 do
-            local entry = ugui.internal.scene[i]
-            if entry.control.uid == ugui.internal.mouse_captured_control then
-                mouse_captured_control = entry
-            end
+        if ugui.internal.mouse_captured_control then
+            mouse_captured_control = find_control_by_uid(ugui.internal.root, ugui.internal.mouse_captured_control)
         end
 
-        ---@type SceneEntry?
+        ---@type SceneNode?
         local keyboard_captured_control = nil
-        for i = 1, #ugui.internal.scene, 1 do
-            local entry = ugui.internal.scene[i]
-            if entry.control.uid == ugui.internal.keyboard_captured_control then
-                keyboard_captured_control = entry
-            end
+        if ugui.internal.keyboard_captured_control then
+            keyboard_captured_control = find_control_by_uid(ugui.internal.root, ugui.internal.keyboard_captured_control)
         end
-
 
         local prev_hovered_control = ugui.internal.hovered_control
         ugui.internal.hovered_control = nil
 
-        for i = #ugui.internal.scene, 1, -1 do
-            local entry = ugui.internal.scene[i]
-            local control = entry.control
-            local registry_entry = ugui.registry[entry.type]
+        traverse_tree_reversed(ugui.internal.root, function(node)
+            local control = node.control
+            local registry_entry = ugui.registry[node.type]
 
             local effective_hittestable = ugui.internal.compute_prop(control, registry_entry, 'hittestable', function() return true end)
 
@@ -346,8 +354,8 @@ ugui.internal = {
                 if ugui.internal.is_mouse_just_down() then
                     if is_point_inside_rectangle(ugui.internal.mouse_down_position, control.rectangle) then
                         clicked_control = control
-                        keyboard_captured_control = entry
-                        mouse_captured_control = entry
+                        keyboard_captured_control = node
+                        mouse_captured_control = node
                     end
                 end
             end
@@ -362,7 +370,7 @@ ugui.internal = {
                     end
                 end
             end
-        end
+        end)
 
         -- Clear the mouse captured control if we released the mouse
         if not ugui.internal.environment.is_primary_down then
@@ -386,12 +394,9 @@ ugui.internal = {
         end
 
         -- Clear hovered control if it's disabled
-        for i = 1, #ugui.internal.scene, 1 do
-            local control = ugui.internal.scene[i].control
-            if control.uid == ugui.internal.hovered_control
-                and control.is_enabled == false then
-                ugui.internal.hovered_control = nil
-            end
+        local hovered_node = ugui.internal.hovered_control and find_control_by_uid(ugui.internal.root, ugui.internal.hovered_control) or nil
+        if hovered_node and hovered_node.control.is_enabled == false then
+            ugui.internal.hovered_control = nil
         end
 
         -- Clear mouse captured control if it's disabled
@@ -405,8 +410,7 @@ ugui.internal = {
         end
 
         ugui.internal.mouse_captured_control = mouse_captured_control and mouse_captured_control.control.uid or nil
-        ugui.internal.keyboard_captured_control = keyboard_captured_control and keyboard_captured_control.control.uid or
-            nil
+        ugui.internal.keyboard_captured_control = keyboard_captured_control and keyboard_captured_control.control.uid or nil
         ugui.internal.clicked_control = clicked_control and clicked_control.uid or nil
     end,
 }

--- a/src/ugui/internal.lua
+++ b/src/ugui/internal.lua
@@ -422,16 +422,23 @@ ugui.internal = {
 
     ---Performs scene layout.
     layout = function()
-        -- Our basic layout rules for now:
-        -- control.rectangle x/y are considered offsets from the parent's x/y
-
         ugui.internal.foreach_node_from_root(function(node)
             local control = node.control
             local parent = node.parent
 
+            local parent_rect = parent and parent.control.rectangle or {x = 0, y = 0, width = 0, height = 0}
 
-            control.rectangle.x = control.rectangle.x + (parent and parent.control.rectangle.x or 0)
-            control.rectangle.y = control.rectangle.y + (parent and parent.control.rectangle.y or 0)
+            local min_x<const> = parent_rect.x
+            local max_x<const> = min_x + parent_rect.width - control.rectangle.width
+
+            local min_y<const> = parent_rect.y
+            local max_y<const> = min_y + parent_rect.height - control.rectangle.height
+
+            local x_offset<const> = ugui.internal.remap(control.x_align or 0, 0, 1, min_x, max_x)
+            local y_offset<const> = ugui.internal.remap(control.y_align or 0, 0, 1, min_y, max_y)
+
+            control.rectangle.x = control.rectangle.x + x_offset
+            control.rectangle.y = control.rectangle.y + y_offset
         end)
     end,
 }

--- a/src/ugui/nineslice.lua
+++ b/src/ugui/nineslice.lua
@@ -122,10 +122,10 @@ ugui.apply_nineslice = function(style)
             ugui.standard_styler.params.color_filter, 'linear')
     end
 
-    ugui.standard_styler.draw_raised_frame = function(control, visual_state)
-        local key = ugui.internal.params_to_key('raised_frame', control.rectangle, visual_state)
+    ugui.standard_styler.draw_raised_frame = function(rectangle, visual_state)
+        local key = ugui.internal.params_to_key('raised_frame', rectangle, visual_state)
 
-        ugui.internal.cached_draw(key, control.rectangle, function(eff_rectangle)
+        ugui.internal.cached_draw(key, rectangle, function(eff_rectangle)
             BreitbandGraphics.draw_image_nineslice(eff_rectangle,
                 style.button.states[visual_state].source,
                 style.button.states[visual_state].center,
@@ -133,7 +133,7 @@ ugui.apply_nineslice = function(style)
         end)
     end
 
-    ugui.standard_styler.draw_edit_frame = function(control, rectangle,
+    ugui.standard_styler.draw_edit_frame = function(rectangle,
                                                     visual_state)
         local key = ugui.internal.params_to_key('edit_frame', rectangle, visual_state)
 

--- a/src/ugui/styler.lua
+++ b/src/ugui/styler.lua
@@ -491,33 +491,26 @@ ugui.standard_styler = {
         end
     end,
 
-    ---Draws a raised frame with the specified parameters.
-    ---@param control Control The control table.
-    ---@param visual_state VisualState The control's visual state.
-    draw_raised_frame = function(control, visual_state)
-        local render_rect = ugui.internal.control_data[control.uid].render_rect
-
-        BreitbandGraphics.fill_rectangle(render_rect,
+    ---@param rectangle Rectangle
+    ---@param visual_state VisualState
+    draw_raised_frame = function(rectangle, visual_state)
+        BreitbandGraphics.fill_rectangle(rectangle,
             ugui.standard_styler.params.button.border[visual_state])
-        BreitbandGraphics.fill_rectangle(BreitbandGraphics.inflate_rectangle(render_rect, -1),
+        BreitbandGraphics.fill_rectangle(BreitbandGraphics.inflate_rectangle(rectangle, -1),
             ugui.standard_styler.params.button.back[visual_state])
     end,
 
-    ---Draws an edit frame with the specified parameters.
-    ---@param control Control The control table.
-    ---@param visual_state VisualState The control's visual state.
-    draw_edit_frame = function(control, rectangle, visual_state)
-        local render_rect = ugui.internal.control_data[control.uid].render_rect
-
-        BreitbandGraphics.fill_rectangle(render_rect,
+    ---@param rectangle Rectangle
+    ---@param visual_state VisualState
+    draw_edit_frame = function(rectangle, visual_state)
+        BreitbandGraphics.fill_rectangle(rectangle,
             ugui.standard_styler.params.textbox.border[visual_state])
-        BreitbandGraphics.fill_rectangle(BreitbandGraphics.inflate_rectangle(render_rect, -1),
+        BreitbandGraphics.fill_rectangle(BreitbandGraphics.inflate_rectangle(rectangle, -1),
             ugui.standard_styler.params.textbox.back[visual_state])
     end,
 
-    ---Draws a list frame with the specified parameters.
-    ---@param rectangle Rectangle The control bounds.
-    ---@param visual_state VisualState The control's visual state.
+    ---@param rectangle Rectangle
+    ---@param visual_state VisualState
     draw_list_frame = function(rectangle, visual_state)
         BreitbandGraphics.fill_rectangle(rectangle,
             ugui.standard_styler.params.listbox.border[visual_state])
@@ -849,7 +842,8 @@ ugui.standard_styler = {
             visual_state = ugui.visual_states.active
         end
 
-        ugui.standard_styler.draw_raised_frame(control, visual_state)
+        local data = ugui.internal.control_data[control.uid]
+        ugui.standard_styler.draw_raised_frame(data.render_rect, visual_state)
     end,
 
     ---Draws a ToggleButton with the specified parameters.
@@ -881,7 +875,7 @@ ugui.standard_styler = {
             visual_state = ugui.visual_states.active
         end
 
-        ugui.standard_styler.draw_edit_frame(control, render_rect, visual_state)
+        ugui.standard_styler.draw_edit_frame(render_rect, visual_state)
         BreitbandGraphics.push_clip(render_rect)
 
         local should_visualize_selection =
@@ -983,6 +977,8 @@ ugui.standard_styler = {
     ---@param control Joystick The control table.
     draw_joystick = function(control)
         local visual_state = ugui.get_visual_state(control)
+        local data = ugui.internal.control_data[control.uid]
+
         local x = control.position and control.position.x or 0
         local y = control.position and control.position.y or 0
         local mag = control.mag or 0
@@ -993,7 +989,7 @@ ugui.standard_styler = {
             visual_state = ugui.visual_states.normal
         end
 
-        ugui.standard_styler.draw_raised_frame(control, visual_state)
+        ugui.standard_styler.draw_raised_frame(data.render_rect, visual_state)
         ugui.standard_styler.draw_joystick_inner(render_rect, visual_state, {
             x = ugui.internal.remap(ugui.internal.clamp(x, -128, 128), -128, 128,
                 render_rect.x, render_rect.x + render_rect.width),
@@ -1093,7 +1089,7 @@ ugui.standard_styler = {
             visual_state = ugui.visual_states.active
         end
 
-        ugui.standard_styler.draw_raised_frame(control, visual_state)
+        ugui.standard_styler.draw_raised_frame(data.render_rect, visual_state)
     end,
 
     ---Draws a ListBox with the specified parameters.

--- a/src/ugui/styler.lua
+++ b/src/ugui/styler.lua
@@ -633,7 +633,7 @@ ugui.standard_styler = {
         local node = ugui.internal.find_node(control.uid)
         ---@cast node SceneNode
 
-        local natural_size = node.natural_size
+        local natural_size = ugui.internal.control_data[node.control.uid].natural_size
         local visual_state = ugui.get_visual_state(control)
         local data = ugui.internal.control_data[control.uid]
 

--- a/src/ugui/styler.lua
+++ b/src/ugui/styler.lua
@@ -630,35 +630,37 @@ ugui.standard_styler = {
     ---@param control ListBox The control table.
     ---@param rectangle Rectangle The list item's bounds.
     draw_list = function(control, rectangle)
+        local node = ugui.internal.find_node(control.uid)
+        ---@cast node SceneNode
+
+        local natural_size = node.natural_size
         local visual_state = ugui.get_visual_state(control)
         local data = ugui.internal.control_data[control.uid]
 
         ugui.standard_styler.draw_list_frame(rectangle, visual_state)
 
-        local content_bounds = ugui.standard_styler.get_desired_listbox_content_bounds(control)
-        -- item y position:
-        -- y = (20 * (i - 1)) - (scroll_y * ((20 * #control.items) - control.rectangle.height))
+
         local scroll_x = data.scroll_x and data.scroll_x or 0
         local scroll_y = data.scroll_y and data.scroll_y or 0
 
         local index_begin = (scroll_y *
-                (content_bounds.height - rectangle.height)) /
+                (natural_size.y - rectangle.height)) /
             ugui.standard_styler.params.listbox_item.height
 
         local index_end = (rectangle.height + (scroll_y *
-                (content_bounds.height - rectangle.height))) /
+                (natural_size.y - rectangle.height))) /
             ugui.standard_styler.params.listbox_item.height
 
         index_begin = ugui.internal.clamp(math.floor(index_begin), 1, #control.items)
         index_end = ugui.internal.clamp(math.ceil(index_end), 1, #control.items)
 
-        local x_offset = math.max((content_bounds.width - control.rectangle.width) * scroll_x, 0)
+        local x_offset = math.max((natural_size.x - control.rectangle.width) * scroll_x, 0)
 
         BreitbandGraphics.push_clip(BreitbandGraphics.inflate_rectangle(rectangle, -1))
 
         for i = index_begin, index_end, 1 do
             local y_offset = (ugui.standard_styler.params.listbox_item.height * (i - 1)) -
-                (scroll_y * (content_bounds.height - rectangle.height))
+                (scroll_y * (natural_size.y - rectangle.height))
 
             local item_visual_state = ugui.visual_states.normal
             if control.is_enabled == false then
@@ -672,7 +674,7 @@ ugui.standard_styler = {
             ugui.standard_styler.draw_list_item(control, control.items[i], {
                 x = rectangle.x - x_offset,
                 y = rectangle.y + y_offset,
-                width = math.max(content_bounds.width, control.rectangle.width),
+                width = math.max(natural_size.x, control.rectangle.width),
                 height = ugui.standard_styler.params.listbox_item.height,
             }, item_visual_state)
         end
@@ -1085,30 +1087,5 @@ ugui.standard_styler = {
     ---@param control ListBox The control table.
     draw_listbox = function(control)
         ugui.standard_styler.draw_list(control, control.rectangle)
-    end,
-
-    ---Gets the desired bounds of a listbox's content.
-    ---@param control table A table abiding by the ugui control contract
-    ---@return _ table A rectangle specifying the desired bounds of the content as `{x = 0, y = 0, width: number, height: number}`.
-    get_desired_listbox_content_bounds = function(control)
-        -- Since horizontal content bounds measuring is expensive, we only do this if explicitly enabled.
-        local max_width = 0
-        if control.horizontal_scroll == true then
-            for _, value in pairs(control.items) do
-                local width = BreitbandGraphics.get_text_size(value, ugui.standard_styler.params.font_size,
-                    ugui.standard_styler.params.font_name).width
-
-                if width > max_width then
-                    max_width = width
-                end
-            end
-        end
-
-        return {
-            x = 0,
-            y = 0,
-            width = max_width,
-            height = ugui.standard_styler.params.listbox_item.height * (control.items and #control.items or 0),
-        }
     end,
 }

--- a/src/ugui/styler.lua
+++ b/src/ugui/styler.lua
@@ -495,9 +495,11 @@ ugui.standard_styler = {
     ---@param control Control The control table.
     ---@param visual_state VisualState The control's visual state.
     draw_raised_frame = function(control, visual_state)
-        BreitbandGraphics.fill_rectangle(control.rectangle,
+        local render_rect = ugui.internal.control_data[control.uid].render_rect
+
+        BreitbandGraphics.fill_rectangle(render_rect,
             ugui.standard_styler.params.button.border[visual_state])
-        BreitbandGraphics.fill_rectangle(BreitbandGraphics.inflate_rectangle(control.rectangle, -1),
+        BreitbandGraphics.fill_rectangle(BreitbandGraphics.inflate_rectangle(render_rect, -1),
             ugui.standard_styler.params.button.back[visual_state])
     end,
 
@@ -505,9 +507,11 @@ ugui.standard_styler = {
     ---@param control Control The control table.
     ---@param visual_state VisualState The control's visual state.
     draw_edit_frame = function(control, rectangle, visual_state)
-        BreitbandGraphics.fill_rectangle(control.rectangle,
+        local render_rect = ugui.internal.control_data[control.uid].render_rect
+
+        BreitbandGraphics.fill_rectangle(render_rect,
             ugui.standard_styler.params.textbox.border[visual_state])
-        BreitbandGraphics.fill_rectangle(BreitbandGraphics.inflate_rectangle(control.rectangle, -1),
+        BreitbandGraphics.fill_rectangle(BreitbandGraphics.inflate_rectangle(render_rect, -1),
             ugui.standard_styler.params.textbox.back[visual_state])
     end,
 
@@ -593,8 +597,9 @@ ugui.standard_styler = {
     ---@param control ScrollBar
     ---@param thumb_rectangle Rectangle The scrollbar thumb's bounds.
     draw_scrollbar = function(control, thumb_rectangle)
+        local render_rect = ugui.internal.control_data[control.uid].render_rect
         local visual_state = ugui.get_visual_state(control)
-        BreitbandGraphics.fill_rectangle(control.rectangle,
+        BreitbandGraphics.fill_rectangle(render_rect,
             ugui.standard_styler.params.scrollbar.back[visual_state])
         BreitbandGraphics.fill_rectangle(thumb_rectangle,
             ugui.standard_styler.params.scrollbar.thumb[visual_state])
@@ -636,6 +641,7 @@ ugui.standard_styler = {
         local natural_size = ugui.internal.control_data[node.control.uid].natural_size
         local visual_state = ugui.get_visual_state(control)
         local data = ugui.internal.control_data[control.uid]
+        local render_rect = data.render_rect
 
         ugui.standard_styler.draw_list_frame(rectangle, visual_state)
 
@@ -654,7 +660,7 @@ ugui.standard_styler = {
         index_begin = ugui.internal.clamp(math.floor(index_begin), 1, #control.items)
         index_end = ugui.internal.clamp(math.ceil(index_end), 1, #control.items)
 
-        local x_offset = math.max((natural_size.x - control.rectangle.width) * scroll_x, 0)
+        local x_offset = math.max((natural_size.x - render_rect.width) * scroll_x, 0)
 
         BreitbandGraphics.push_clip(BreitbandGraphics.inflate_rectangle(rectangle, -1))
 
@@ -674,7 +680,7 @@ ugui.standard_styler = {
             ugui.standard_styler.draw_list_item(control, control.items[i], {
                 x = rectangle.x - x_offset,
                 y = rectangle.y + y_offset,
-                width = math.max(natural_size.x, control.rectangle.width),
+                width = math.max(natural_size.x, render_rect.width),
                 height = ugui.standard_styler.params.listbox_item.height,
             }, item_visual_state)
         end
@@ -865,6 +871,7 @@ ugui.standard_styler = {
     ---@param control TextBox The control table.
     draw_textbox = function(control)
         local data = ugui.internal.control_data[control.uid]
+        local render_rect = data.render_rect
         local visual_state = ugui.get_visual_state(control)
         local text = control.text
         local scrolled_text = control.text:sub(data.scroll_offset)
@@ -874,8 +881,8 @@ ugui.standard_styler = {
             visual_state = ugui.visual_states.active
         end
 
-        ugui.standard_styler.draw_edit_frame(control, control.rectangle, visual_state)
-        BreitbandGraphics.push_clip(control.rectangle)
+        ugui.standard_styler.draw_edit_frame(control, render_rect, visual_state)
+        BreitbandGraphics.push_clip(render_rect)
 
         local should_visualize_selection =
             control.is_enabled ~= false
@@ -884,7 +891,7 @@ ugui.standard_styler = {
 
         local string_to_caret = text:sub(data.scroll_offset, data.caret_index - 1)
         local string_to_caret_width = BreitbandGraphics.get_text_size(string_to_caret, ugui.standard_styler.params.font_size, ugui.standard_styler.params.font_name).width
-        local caret_x = control.rectangle.x + ugui.standard_styler.params.textbox.padding.x + string_to_caret_width
+        local caret_x = render_rect.x + ugui.standard_styler.params.textbox.padding.x + string_to_caret_width
         local string_to_selection_start
         local string_to_selection_end
         local string_to_selection_start_width
@@ -900,14 +907,14 @@ ugui.standard_styler = {
             string_to_selection_start_width = BreitbandGraphics.get_text_size(string_to_selection_start, ugui.standard_styler.params.font_size, ugui.standard_styler.params.font_name).width
             string_to_selection_end_width = BreitbandGraphics.get_text_size(string_to_selection_end, ugui.standard_styler.params.font_size, ugui.standard_styler.params.font_name).width
 
-            selection_start_x = control.rectangle.x + ugui.standard_styler.params.textbox.padding.x + string_to_selection_start_width
-            selection_end_x = control.rectangle.x + ugui.standard_styler.params.textbox.padding.x + string_to_selection_end_width
+            selection_start_x = render_rect.x + ugui.standard_styler.params.textbox.padding.x + string_to_selection_start_width
+            selection_end_x = render_rect.x + ugui.standard_styler.params.textbox.padding.x + string_to_selection_end_width
         end
 
         if should_visualize_selection then
             BreitbandGraphics.fill_rectangle({
-                    x = control.rectangle.x + ugui.standard_styler.params.textbox.padding.x + string_to_selection_start_width,
-                    y = control.rectangle.y,
+                    x = render_rect.x + ugui.standard_styler.params.textbox.padding.x + string_to_selection_start_width,
+                    y = render_rect.y,
                     width = string_to_selection_end_width - string_to_selection_start_width,
                     height = caret_height,
                 },
@@ -915,10 +922,10 @@ ugui.standard_styler = {
         end
 
         local text_rect = {
-            x = control.rectangle.x + ugui.standard_styler.params.textbox.padding.x,
-            y = control.rectangle.y,
+            x = render_rect.x + ugui.standard_styler.params.textbox.padding.x,
+            y = render_rect.y,
             width = 9999,
-            height = control.rectangle.height,
+            height = render_rect.height,
         }
 
         BreitbandGraphics.draw_text2({
@@ -935,9 +942,9 @@ ugui.standard_styler = {
         if should_visualize_selection then
             BreitbandGraphics.push_clip({
                 x = selection_start_x,
-                y = control.rectangle.y,
+                y = render_rect.y,
                 width = selection_end_x - selection_start_x,
-                height = control.rectangle.height,
+                height = render_rect.height,
             })
 
             BreitbandGraphics.draw_text2({
@@ -958,10 +965,10 @@ ugui.standard_styler = {
         if visual_state == ugui.visual_states.active and math.floor(os.clock() * 2) % 2 == 0 and not should_visualize_selection then
             BreitbandGraphics.draw_line({
                 x = caret_x,
-                y = control.rectangle.y + 3,
+                y = render_rect.y + 3,
             }, {
                 x = caret_x,
-                y = control.rectangle.y + caret_height - 3,
+                y = render_rect.y + caret_height - 3,
             }, {
                 r = 0,
                 g = 0,
@@ -979,6 +986,7 @@ ugui.standard_styler = {
         local x = control.position and control.position.x or 0
         local y = control.position and control.position.y or 0
         local mag = control.mag or 0
+        local render_rect = ugui.internal.control_data[control.uid].render_rect
 
         -- joystick has no hover or active states
         if not (visual_state == ugui.visual_states.disabled) then
@@ -986,31 +994,33 @@ ugui.standard_styler = {
         end
 
         ugui.standard_styler.draw_raised_frame(control, visual_state)
-        ugui.standard_styler.draw_joystick_inner(control.rectangle, visual_state, {
+        ugui.standard_styler.draw_joystick_inner(render_rect, visual_state, {
             x = ugui.internal.remap(ugui.internal.clamp(x, -128, 128), -128, 128,
-                control.rectangle.x, control.rectangle.x + control.rectangle.width),
+                render_rect.x, render_rect.x + render_rect.width),
             y = ugui.internal.remap(ugui.internal.clamp(y, -128, 128), -128, 128,
-                control.rectangle.y, control.rectangle.y + control.rectangle.height),
+                render_rect.y, render_rect.y + render_rect.height),
             r = ugui.internal.remap(ugui.internal.clamp(mag, 0, 128), 0, 128, 0,
-                math.min(control.rectangle.width, control.rectangle.height)),
+                math.min(render_rect.width, render_rect.height)),
         })
     end,
     draw_track = function(control, visual_state, is_horizontal)
         local track_rectangle = {}
+        local render_rect = ugui.internal.control_data[control.uid].render_rect
+
         if not is_horizontal then
             track_rectangle = {
-                x = control.rectangle.x + control.rectangle.width / 2 -
+                x = render_rect.x + render_rect.width / 2 -
                     ugui.standard_styler.params.trackbar.track_thickness / 2,
-                y = control.rectangle.y,
+                y = render_rect.y,
                 width = ugui.standard_styler.params.trackbar.track_thickness,
-                height = control.rectangle.height,
+                height = render_rect.height,
             }
         else
             track_rectangle = {
-                x = control.rectangle.x,
-                y = control.rectangle.y + control.rectangle.height / 2 -
+                x = render_rect.x,
+                y = render_rect.y + render_rect.height / 2 -
                     ugui.standard_styler.params.trackbar.track_thickness / 2,
-                width = control.rectangle.width,
+                width = render_rect.width,
                 height = ugui.standard_styler.params.trackbar.track_thickness,
             }
         end
@@ -1028,23 +1038,25 @@ ugui.standard_styler = {
     ---@param value number The trackbar's value.
     draw_thumb = function(control, visual_state, is_horizontal, value)
         local head_rectangle = {}
+        local render_rect = ugui.internal.control_data[control.uid].render_rect
+
         local effective_bar_height = math.min(
-            (is_horizontal and control.rectangle.height or control.rectangle.width) * 2,
+            (is_horizontal and render_rect.height or render_rect.width) * 2,
             ugui.standard_styler.params.trackbar.bar_height)
         if not is_horizontal then
             head_rectangle = {
-                x = control.rectangle.x + control.rectangle.width / 2 -
+                x = render_rect.x + render_rect.width / 2 -
                     effective_bar_height / 2,
-                y = control.rectangle.y + (value * control.rectangle.height) -
+                y = render_rect.y + (value * render_rect.height) -
                     ugui.standard_styler.params.trackbar.bar_width / 2,
                 width = effective_bar_height,
                 height = ugui.standard_styler.params.trackbar.bar_width,
             }
         else
             head_rectangle = {
-                x = control.rectangle.x + (value * control.rectangle.width) -
+                x = render_rect.x + (value * render_rect.width) -
                     ugui.standard_styler.params.trackbar.bar_width / 2,
-                y = control.rectangle.y + control.rectangle.height / 2 -
+                y = render_rect.y + render_rect.height / 2 -
                     effective_bar_height / 2,
                 width = ugui.standard_styler.params.trackbar.bar_width,
                 height = effective_bar_height,
@@ -1059,12 +1071,13 @@ ugui.standard_styler = {
     draw_trackbar = function(control)
         local visual_state = ugui.get_visual_state(control)
         local data = ugui.internal.control_data[control.uid]
+        local render_rect = ugui.internal.control_data[control.uid].render_rect
 
         if ugui.internal.mouse_captured_control == control.uid and control.is_enabled ~= false then
             visual_state = ugui.visual_states.active
         end
 
-        local is_horizontal = control.rectangle.width > control.rectangle.height
+        local is_horizontal = render_rect.width > render_rect.height
 
         ugui.standard_styler.draw_track(control, visual_state, is_horizontal)
         ugui.standard_styler.draw_thumb(control, visual_state, is_horizontal, data.value)
@@ -1086,6 +1099,7 @@ ugui.standard_styler = {
     ---Draws a ListBox with the specified parameters.
     ---@param control ListBox The control table.
     draw_listbox = function(control)
-        ugui.standard_styler.draw_list(control, control.rectangle)
+        local render_rect = ugui.internal.control_data[control.uid].render_rect
+        ugui.standard_styler.draw_list(control, render_rect)
     end,
 }

--- a/src/ugui/styler.lua
+++ b/src/ugui/styler.lua
@@ -784,7 +784,7 @@ ugui.standard_styler = {
         end
         local rectangle = {x = position.x, y = position.y, width = 0, height = 0}
         local size = ugui.standard_styler.compute_rich_text(text, control.plaintext,
-        ugui.standard_styler.params.font_name, ugui.standard_styler.params.font_size).size
+            ugui.standard_styler.params.font_name, ugui.standard_styler.params.font_size).size
         rectangle.width = size.x
         rectangle.height = math.max(size.y, ugui.standard_styler.params.menu_item.height)
         rectangle.y = rectangle.y + rectangle.height
@@ -842,8 +842,6 @@ ugui.standard_styler = {
         end
 
         ugui.standard_styler.draw_raised_frame(control, visual_state)
-        ugui.standard_styler.draw_rich_text(control.rectangle, nil, nil, control.text,
-            ugui.standard_styler.params.button.text[visual_state], visual_state, control.plaintext)
     end,
 
     ---Draws a ToggleButton with the specified parameters.
@@ -859,23 +857,6 @@ ugui.standard_styler = {
         local copy = ugui.internal.deep_clone(control)
         copy.text = control.items and control.items[control.selected_index] or ''
         ugui.standard_styler.draw_button(copy)
-
-        local visual_state = ugui.get_visual_state(control)
-
-        -- draw the arrows
-        ugui.standard_styler.draw_icon({
-            x = control.rectangle.x + ugui.standard_styler.params.textbox.padding.x,
-            y = control.rectangle.y,
-            width = ugui.standard_styler.params.icon_size,
-            height = control.rectangle.height,
-        }, ugui.standard_styler.params.button.text[visual_state], visual_state, 'arrow_left')
-        ugui.standard_styler.draw_icon({
-            x = control.rectangle.x + control.rectangle.width - ugui.standard_styler.params.textbox.padding.x -
-                ugui.standard_styler.params.icon_size,
-            y = control.rectangle.y,
-            width = ugui.standard_styler.params.icon_size,
-            height = control.rectangle.height,
-        }, ugui.standard_styler.params.button.text[visual_state], visual_state, 'arrow_right')
     end,
 
     ---Draws a TextBox with the specified parameters.
@@ -1092,32 +1073,12 @@ ugui.standard_styler = {
     draw_combobox = function(control)
         local visual_state = ugui.get_visual_state(control)
         local data = ugui.internal.control_data[control.uid]
-        local selected_item = data.selected_index == nil and '' or control.items[data.selected_index]
 
         if data.open and control.is_enabled ~= false then
             visual_state = ugui.visual_states.active
         end
 
         ugui.standard_styler.draw_raised_frame(control, visual_state)
-
-        local text_color = ugui.standard_styler.params.button.text[visual_state]
-
-        local text_rect = {
-            x = control.rectangle.x + ugui.standard_styler.params.textbox.padding.x * 2,
-            y = control.rectangle.y,
-            width = control.rectangle.width,
-            height = control.rectangle.height,
-        }
-
-        ugui.standard_styler.draw_rich_text(text_rect, BreitbandGraphics.alignment.start, nil, selected_item, text_color,
-            visual_state, control.plaintext)
-        ugui.standard_styler.draw_icon({
-            x = control.rectangle.x + control.rectangle.width - ugui.standard_styler.params.icon_size -
-                ugui.standard_styler.params.textbox.padding.x * 2,
-            y = control.rectangle.y,
-            width = ugui.standard_styler.params.icon_size,
-            height = control.rectangle.height,
-        }, text_color, visual_state, 'arrow_down')
     end,
 
     ---Draws a ListBox with the specified parameters.


### PR DESCRIPTION
# TODO

- [ ] Layout tests (just some basic render_rect comparisons)
- [ ] Test compat in Redux

## Breaking Changes

### UID slot changes

Various controls now use more UID slots due to internal changes.

`button` - 2 slots
`toggle_button` - 2 slots
`carrousel_button` - 4 slots
`combobox` - 9 slots
`spinner` - 9 slots
`tabcontrol` - `n(children) * 2 + 1`

Tip: if you find yourself having to fix UID-related breakage often, space out the UIDs in your scene by `100` - it's easy to keep an eye on and reasonably safe against future breakage.

### Reserved UID

UID `math.mininteger` is now reserved by ugui and can't be used by library consumers. If you're using that UID, change it to something else.

### Control references

While not explicitly documented anywhere, previous versions of ugui somewhat tolerated holding on to a `Control` instance after it's consumed by `ugui.control` (or one of the control placing functions like `ugui.button`).

This behavior is now out the window: reading back from control tables after they're consumed is undefined behavior.

Barely any library consumers rely on this behavior, but if you do, you can re-architect your script to store data in a safe local context instead of smuggling it through ugui.




---------------




## Templated controls

`ugui.control` as well as all control spawning functions (e.g. `ugui.button`) now have an additional parameter, `fn`.

`fn` is a callback that's called immediately after the control was placed. Any controls placed within the callback will be parented to the newly placed control.

It's important to note that **the controls themselves decide when `fn` is called**. Therefore, it behaves more like a slot, similar to WPF's `ContentPresenter`.

Many controls now place children by default, but this isn't something public API consumers should care about.

## `Control.rectangle`

The `Control.rectangle` field has been deprecated.

Any usages of it will be internally translated to margins and sizes (see below).

## Control positioning and sizing

The positioning and sizing of controls is now controlled via the `Control.margin`, `Control.align`, `Control.size`, and `Control.padding` properties. See [the docs](https://github.com/mupen64/ugui/blob/scene-tree/src/ugui/controls/control.lua).

Note the `Smart[...]` units.

## Units

A unit system has been introduced. If you're familiar with CSS units, these are basically a barebones version of that.

See the docs for more.